### PR TITLE
v1.0.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ You can use the `toc`-Tag as you would use any recursive tag (like the `nav` Tag
     </ol>
     {{ /if }}
   </li>
-  {{ /toc }}
+  {{ /toc }}
 </ol>
 ```
 
@@ -148,7 +148,7 @@ If you don't want to display your ToC as a nested list you can pass the paramete
   <li>
     <a href="#{{ toc_id }}">{{ toc_title }}</a>
   </li>
-  {{ /toc }}
+  {{ /toc }}
 </ol>
 ```
 
@@ -160,11 +160,20 @@ Every Item has the following variables at your disposal:
 | ----------------------- | ----------------------------------------------------------- |
 | `toc_title` _(string)_  | The title of the heading                                    |
 | ` toc_id` _(string)_    | The slugified title to use as anchor-id                     |
-| `id` (int)              |  The internal id used to assign children and parents        |
+| `id` (int)              |  The internal id used to assign children and parents        |
 | ` is_root` _(bool)_     | A flag to determine if the current heading is at root level |
 | `parent` _(int/null)_   | Id of parent item if current item is a child                |
-| `has_children` _(bool)_ |  Flag if current item has children                          |
+| `has_children` _(bool)_ |  Flag if current item has children                          |
 | `children` _(array)_    | Contains all the Child-headings                             |
+| `total_children` _(int)_| Number of children (only if `has_children` is true)         |
+
+Also, there are the following global variables present inside the `toc` tag:
+
+| Variable                | Description                                      |
+| ----------------------- | ------------------------------------------------ |
+| `total_results` _(int)_ | The number of total headings including children. |
+| `no_results` _(bool)_   | True if no results are present                   |
+
 
 ### Parameters
 

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -176,7 +176,8 @@ class Parser
                 "content" => [
                     [
                         "type" => "text",
-                        "text" => $tag->nodeValue,
+                        // force utf-8 decoding
+                        "text" => utf8_decode($tag->nodeValue),
                     ],
                 ],
             ]);
@@ -302,7 +303,8 @@ class Parser
             function ($matches) {
                 // the html tag
                 $tag = $matches[1];
-                $title = strip_tags($matches[3]);
+                // decode html entities to support special characters in headings/slug
+                $title = html_entity_decode(strip_tags($matches[3]));
                 $hasId = preg_match('/id=(["\'])(.*?)\1[\s>]/si', $matches[2], $matchedIds);
                 $id = $hasId ? $matchedIds[2] : $this->generateId($title, false);
 

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -206,8 +206,8 @@ class Parser
             // iterate through each heading and push its information into
             // an array.
             $headings->each(function ($heading, $key) use (&$tocArray) {
-                // Check, if the content type is really text
-                if ($heading["content"][0]["type"] !== "text") {
+                // Check, if the heading isn't empty or if the content type is really text
+                if (!isset($heading["content"]) || $heading["content"][0]["type"] !== "text") {
                     return;
                 }
 

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -129,10 +129,35 @@ class Parser
      */
     public function build(): array
     {
+        return $this->supplementExtraOutput(
+            $this->generate()
+        );
+    }
+
+    private function generate(): array
+    {
         if ($this->isHTML()) {
             return $this->generateFromHtml();
         }
-        return $this->generateFromStructure();
+        return  $this->generateFromStructure();
+    }
+
+    public function supplementExtraOutput(array $toc): array
+    {
+        $extra = [];
+
+        $count = count($this->flatten()->generate());
+        $extra['total_results'] = $count;
+
+        if ($count < 1) {
+            $extra['no_results'] = true;
+        }
+
+        if (count($toc) > 0) {
+            return array_merge($toc[0], $extra);
+        }
+
+        return $extra;
     }
 
     /**
@@ -285,6 +310,7 @@ class Parser
             if ($children = $this->nestHeadings($heading['id'])) {
                 $length = count($headings);
                 $headings[$length - 1]['children'] = $children;
+                $headings[$length - 1]['total_children'] = count($children);
             }
         }
         return empty($headings) ? [] : $headings;


### PR DESCRIPTION
Fixes #9 and #8 and also introduces 2 new variables:
- `total_results` (count all results including child elements)
- `total_children` (count only child elements)