### PR TITLE
v1.9: PR #33 und #34 zusammengeführt

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,10 +12,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - php: "8.1"
+          # Every laravel/framework release below 12 carries unpatched security
+          # advisories, which Composer refuses to install. Statamic 5 supports
+          # Laravel 12 since 5.66, so the Statamic 5 leg runs there.
+          - php: "8.2"
             statamic: "5.*"
-            laravel: "10.*"
-            testbench: "8.*"
+            laravel: "12.*"
+            testbench: "10.*"
             os: ubuntu-latest
           - php: "8.2"
             statamic: "6.*"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to `statamic-toc` will be documented in this file.
 
+## 2026-07-30 v1.8
+
+- Headings inside nested Bard sets (columns, grids, replicators) are now found. Previously only
+  top-level nodes were scanned.
+- Headings with inline formatting (bold, italic, links) keep their full text. Before, a heading
+  starting with a mark was dropped entirely and a heading containing one was cut short (#26).
+- Malformed Bard nodes no longer cause fatal errors: missing `attrs`, missing, empty or
+  non-array `content`, and non-numeric levels are skipped instead.
+- `from()` no longer expands the depth when called after `depth()` or called twice.
+- New `exclude` parameter on the tag: comma-separated headings or a regex pattern.
+- Headings that normalize to an empty string are left out of the list.
+- Test suite: three test classes were silently skipped on PHPUnit 12 because doc-comment
+  annotations are no longer read. Method names now carry the `test_` prefix, which works on
+  every supported PHPUnit version.
+
 ## ???-??-?? v1.05
 
 - Support for Statamic v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to `statamic-toc` will be documented in this file.
 
-## 2026-07-30 v1.8
+## 2026-07-30 v1.9
 
 - Headings inside nested Bard sets (columns, grids, replicators) are now found. Previously only
   top-level nodes were scanned.
@@ -17,7 +17,7 @@ All notable changes to `statamic-toc` will be documented in this file.
   annotations are no longer read. Method names now carry the `test_` prefix, which works on
   every supported PHPUnit version.
 
-## ???-??-?? v1.05
+## 2026-04-08 v1.8
 
 - Support for Statamic v6
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,44 @@ If you don't want to display your ToC as a nested list you can pass the paramete
 </ol>
 ```
 
+### Excluding headings
+
+Pass `exclude` to leave individual headings out of the list. A comma-separated string matches
+case-insensitively on any part of the heading text:
+
+```
+{{ toc exclude="Introduction, Footnotes" }}
+```
+
+A delimited pattern is treated as a regular expression:
+
+```
+{{ toc exclude="/^Appendix/i" }}
+```
+
+The excluded headings still receive their IDs from the modifier, they are only omitted from the list.
+
+### Conditional output
+
+`when` switches the tag off without removing it from the template:
+
+```
+{{ toc :when="show_toc" }}
+```
+
+When it evaluates to `false`, the tag returns an empty list and `no_results` is true.
+
+### The `toc:count` Tag
+
+Returns the number of headings found. Pass it the same `field`, `depth` and `from` parameters as
+the list itself, otherwise it counts a different set:
+
+```
+{{ if {toc:count field="article" depth="3"} > 0 }}
+  ...
+{{ /if }}
+```
+
 ### Variables
 
 Every Item has the following variables at your disposal:
@@ -203,7 +241,9 @@ You can control the behaviour with the following tag-parameters:
 | `is_flat` | When true the list will be displayed as a flat array without nested `children` | _(boolean)_ `false`          |
 | `field`   | The name of the bard-field.                                                    | _(string)_ `"article"`       |
 | `content` | Content of the bard-structure or HTML String                                   | _(string/array/null)_ `null` |
-| `from`    | The starting point from where the list shohuld be outputted                    | _(string)_ `h1`              |
+| `from`    | The starting point from where the list should be outputted                     | _(string)_ `h1`              |
+| `exclude` | Comma-separated headings or a regex pattern to omit from the list              | _(string/null)_ `null`       |
+| `when`    | Returns an empty list when this evaluates to false                             | _(bool)_ `true`              |
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -204,6 +204,33 @@ Example:
 {{ /if }}
 ```
 
+### Excluding headings
+
+Pass `exclude` to leave individual headings out of the list. A comma-separated string matches
+case-insensitively on any part of the heading text:
+
+```
+{{ toc exclude="Introduction, Footnotes" }}
+```
+
+A delimited pattern is treated as a regular expression:
+
+```
+{{ toc exclude="/^Appendix/i" }}
+```
+
+The excluded headings still receive their IDs from the modifier, they are only omitted from the list.
+
+### Conditional output
+
+`when` switches the tag off without removing it from the template:
+
+```
+{{ toc :when="show_toc" }}
+```
+
+When it evaluates to `false`, the tag returns an empty list and `no_results` is true.
+
 ### Variables
 
 Every Item has the following variables at your disposal:
@@ -236,7 +263,9 @@ You can control the behaviour with the following tag-parameters:
 | `is_flat` | When true the list will be displayed as a flat array without nested `children` | _(boolean)_ `false`          |
 | `field`   | The name of the bard-field.                                                    | _(string)_ `"article"`       |
 | `content` | Content of the bard-structure or HTML String                                   | _(string/array/null)_ `null` |
-| `from`    | The starting point from where the list shohuld be outputted                    | _(string)_ `h1`              |
+| `from`    | The starting point from where the list should be outputted                     | _(string)_ `h1`              |
+| `exclude` | Comma-separated headings or a regex pattern to omit from the list              | _(string/null)_ `null`       |
+| `when`    | Returns an empty list when this evaluates to false                             | _(bool)_ `true`              |
 
 ## License
 

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -20,6 +20,8 @@ class Parser
     private $minLevel = 1;
 
     private $headings = [];
+    
+    private $exclude;
 
     private $isFlat = false;
 
@@ -129,16 +131,30 @@ class Parser
             $start = 6;
         }
 
+        $currentDepth = $this->maxLevel - $this->minLevel + 1;
         $this->minLevel = $start;
-        // our depth is relative to the minLevel. So we need to update is if
+        // our depth is relative to the minLevel. So we need to update it if
         // the minLevel changes
-        $this->depth($this->maxLevel);
+        $this->depth($currentDepth);
 
         return $this;
     }
 
     /**
-     * Sets a marker so the list won't be proicessed recursively.
+     * Set the exclusion pattern
+     * 
+     * @param string|null $exclude
+     * @return $this
+     */
+    public function exclude($exclude)
+    {
+        $this->exclude = $exclude;
+
+        return $this;
+    }
+
+    /**
+     * Sets a marker so the list won't be processed recursively.
      *
      * @return $this
      */
@@ -282,30 +298,16 @@ class Parser
     private function generateFromStructure($structure = null): array
     {
         // create a collection with the content array
-        $raw = ! $structure ? collect($this->content) : collect($structure);
+        $raw = ! $structure ? $this->content : $structure;
 
-        // filter out all the headings
-        $headings = $raw->filter(function ($item) {
-            return is_array($item) && $item['type'] === 'heading' && $item['attrs']['level'] >= $this->minLevel && $item['attrs']['level'] <= $this->maxLevel;
-        });
+        if (! is_array($raw)) {
+            return [];
+        }
 
-        if ($headings->count() > 0) {
-            // iterate through each heading and push its information into
-            // an array.
-            $headings->each(function ($heading, $key) use (&$tocArray) {
-                // Check, if the heading isn't empty or if the content type is really text
-                if (! isset($heading['content']) || $heading['content'][0]['type'] !== 'text') {
-                    return;
-                }
+        $this->collectHeadingsRecursively($raw);
 
-                $title = $heading['content'][0]['text'];
-                $this->headings[] = [
-                    'toc_title' => $title,
-                    'level' => $heading['attrs']['level'],
-                    'toc_id' => $this->generateId($title, true),
-                ];
-                $this->headings[count($this->headings) - 1]['id'] = count($this->headings);
-            });
+        if (empty($this->headings)) {
+            return [];
         }
 
         // get root & max level info
@@ -361,6 +363,108 @@ class Parser
 
         // return flat array if flag is true, nest it if not
         return $this->isFlat ? $this->headings : $this->nestHeadings();
+    }
+
+    /**
+     * Recursive function to collect headings from a Bard/Structure array.
+     */
+    private function collectHeadingsRecursively($items)
+    {
+        if (! is_array($items)) {
+            return;
+        }
+
+        // If it's a sequential array (a list of nodes or sets)
+        if (isset($items[0])) {
+            foreach ($items as $item) {
+                $this->collectHeadingsRecursively($item);
+            }
+
+            return;
+        }
+
+        // Processing a single node or set (keyed array)
+        if (isset($items['type']) && $items['type'] === 'heading') {
+            $level = $items['attrs']['level'] ?? 0;
+            if (is_numeric($level) && $level >= $this->minLevel && $level <= $this->maxLevel) {
+                // 'content' can be missing or a scalar on malformed Bard nodes.
+                $content = $items['content'] ?? [];
+                $title = is_array($content) ? $this->normalizeHeadingText($content) : '';
+
+                if ($title !== '' && $this->shouldIncludeHeading($title)) {
+                    $this->headings[] = [
+                        'toc_title' => $title,
+                        'level' => (int) $level,
+                        'toc_id' => $this->generateId($title, true),
+                        'id' => count($this->headings) + 1,
+                    ];
+                }
+            }
+        }
+
+        // Recurse into all properties that are arrays (except 'attrs' unless it's a set)
+        foreach ($items as $key => $value) {
+            if (! is_array($value)) {
+                continue;
+            }
+
+            if ($key === 'attrs' && isset($items['type']) && $items['type'] !== 'set') {
+                continue;
+            }
+
+            $this->collectHeadingsRecursively($value);
+        }
+    }
+
+    /**
+     * Normalizes heading text by concatenating all text segments.
+     */
+    private function normalizeHeadingText(array $content): string
+    {
+        $text = '';
+        foreach ($content as $node) {
+            if (! is_array($node)) {
+                continue;
+            }
+
+            if (isset($node['text']) && is_scalar($node['text'])) {
+                $text .= $node['text'];
+            } elseif (isset($node['content']) && is_array($node['content'])) {
+                $text .= $this->normalizeHeadingText($node['content']);
+            }
+        }
+
+        return trim($text);
+    }
+
+    /**
+     * Checks if a heading should be included based on the exclusion pattern.
+     */
+    private function shouldIncludeHeading(string $title): bool
+    {
+        if (! $this->exclude) {
+            return true;
+        }
+
+        // Treat as regex only when it looks like a delimited pattern (e.g. /foo/i).
+        // This avoids calling preg_match on plain strings, which would emit warnings.
+        if (preg_match('/^([^\w\s\\\\])[^\1]*\1[gimsuy]*$/', $this->exclude)) {
+            try {
+                return ! preg_match($this->exclude, $title);
+            } catch (\Throwable $e) {
+                // Invalid regex — fall through to string match
+            }
+        }
+
+        // Comma-separated string match; skip empty tokens to avoid matching everything
+        foreach (explode(',', $this->exclude) as $exc) {
+            $exc = trim($exc);
+            if ($exc !== '' && stripos($title, $exc) !== false) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/src/Tags/Toc.php
+++ b/src/Tags/Toc.php
@@ -63,11 +63,17 @@ class Toc extends Tags
         }
 
         $isFlat = $this->params->bool("is_flat");
+        $exclude = $this->params->get("exclude");
+        if ($exclude instanceof \Statamic\Fields\Value) {
+            $exclude = $exclude->raw();
+        }
+        $exclude = $exclude ? (string) $exclude : null;
 
         // create parser and generate TOC items
         $toc = new Parser($raw);
         $toc->depth($depth)
             ->from($start)
+            ->exclude($exclude)
             ->flattenIf($isFlat);
 
         return $this->output(

--- a/tests/Unit/ModifierTest.php
+++ b/tests/Unit/ModifierTest.php
@@ -16,14 +16,12 @@ class ModifierTest extends TestCase
     $this->modifier = resolve(Toc::class);
   }
 
-  /** @test */
   public function test_modifier_outputs_string()
   {
     $output = $this->modifier->index(new Value($this->fakeHTMLContent(2, 3)));
     $this->assertIsString($output);
   }
 
-  /** @test */
   public function test_modifier_adds_slugified_id_to_heading()
   {
     $output = $this->modifier->index(new Value($this->fakeHTMLContent(2, 3)));

--- a/tests/Unit/ModifierTest.php
+++ b/tests/Unit/ModifierTest.php
@@ -17,14 +17,14 @@ class ModifierTest extends TestCase
   }
 
   /** @test */
-  public function modifier_outputs_string()
+  public function test_modifier_outputs_string()
   {
     $output = $this->modifier->index(new Value($this->fakeHTMLContent(2, 3)));
     $this->assertIsString($output);
   }
 
   /** @test */
-  public function modifier_adds_slugified_id_to_heading()
+  public function test_modifier_adds_slugified_id_to_heading()
   {
     $output = $this->modifier->index(new Value($this->fakeHTMLContent(2, 3)));
     $this->assertStringContainsString('id="heading-1"', $output);

--- a/tests/Unit/ParserSafetyTest.php
+++ b/tests/Unit/ParserSafetyTest.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace Tests\Unit;
+
+use Goldnead\StatamicToc\Parser;
+use Goldnead\StatamicToc\Tests\TestCase;
+
+class ParserSafetyTest extends TestCase
+{
+    /** @test */
+    public function test_handles_heading_with_missing_attrs()
+    {
+        $content = [
+            [
+                'type' => 'heading',
+                // missing 'attrs' entirely
+                'content' => [['type' => 'text', 'text' => 'Test']],
+            ],
+        ];
+
+        $result = (new Parser($content))->build();
+
+        $this->assertIsArray($result);
+        $this->assertEquals(0, $result['total_results']);
+    }
+
+    /** @test */
+    public function test_handles_heading_with_missing_content()
+    {
+        $content = [
+            [
+                'type' => 'heading',
+                'attrs' => ['level' => 2],
+                // missing 'content' entirely
+            ],
+        ];
+
+        $result = (new Parser($content))->build();
+
+        $this->assertIsArray($result);
+        $this->assertEquals(0, $result['total_results']);
+    }
+
+    /** @test */
+    public function test_handles_heading_with_empty_content_array()
+    {
+        $content = [
+            [
+                'type' => 'heading',
+                'attrs' => ['level' => 2],
+                'content' => [],
+            ],
+        ];
+
+        $result = (new Parser($content))->build();
+
+        $this->assertIsArray($result);
+        $this->assertEquals(0, $result['total_results']);
+    }
+
+    /** @test */
+    public function test_handles_items_missing_type_key()
+    {
+        $content = [
+            ['text' => 'not a heading'],
+            [
+                'type' => 'heading',
+                'attrs' => ['level' => 2],
+                'content' => [['type' => 'text', 'text' => 'Valid']],
+            ],
+        ];
+
+        $result = (new Parser($content))->build();
+
+        $this->assertIsArray($result);
+        // When results exist, total_results is attached to the first item
+        $this->assertEquals(1, $result[0]['total_results']);
+    }
+
+    /** @test */
+    public function test_handles_content_first_element_not_array()
+    {
+        $content = [
+            [
+                'type' => 'heading',
+                'attrs' => ['level' => 2],
+                'content' => ['not an array element'],
+            ],
+        ];
+
+        $result = (new Parser($content))->build();
+
+        $this->assertIsArray($result);
+        $this->assertEquals(0, $result['total_results']);
+    }
+
+    /** @test */
+    public function test_handles_scalar_content()
+    {
+        // A malformed Bard node whose 'content' is a scalar (e.g. an int)
+        // instead of an array must not crash on the content dereference.
+        $content = [
+            [
+                'type' => 'heading',
+                'attrs' => ['level' => 2],
+                'content' => 123,
+            ],
+        ];
+
+        $result = (new Parser($content))->build();
+
+        $this->assertIsArray($result);
+        $this->assertEquals(0, $result['total_results']);
+    }
+
+    /** @test */
+    public function test_handles_non_numeric_level()
+    {
+        $content = [
+            [
+                'type' => 'heading',
+                'attrs' => ['level' => 'zwei'],
+                'content' => [['type' => 'text', 'text' => 'Test']],
+            ],
+        ];
+
+        $result = (new Parser($content))->build();
+
+        $this->assertIsArray($result);
+        $this->assertEquals(0, $result['total_results']);
+    }
+
+    /** @test */
+    public function test_handles_content_first_element_missing_text_key()
+    {
+        $content = [
+            [
+                'type' => 'heading',
+                'attrs' => ['level' => 2],
+                'content' => [['type' => 'text']], // missing 'text' key
+            ],
+        ];
+
+        $result = (new Parser($content))->build();
+
+        $this->assertIsArray($result);
+        $this->assertEquals(0, $result['total_results']);
+    }
+
+    /** @test */
+    public function test_from_preserves_depth_when_minlevel_changes()
+    {
+        // depth(2) from h2 should only include h2 and h3, not h4
+        $html = '<h2>A</h2><h3>B</h3><h4>C</h4>';
+
+        $result = (new Parser($html))->from('h2')->depth(2)->build();
+
+        $this->assertCount(1, $result);
+        $this->assertEquals('A', $result[0]['toc_title']);
+        $this->assertCount(1, $result[0]['children']);
+        $this->assertEquals('B', $result[0]['children'][0]['toc_title']);
+        $this->assertEmpty($result[0]['children'][0]['children'] ?? []);
+    }
+
+    /** @test */
+    public function test_from_called_twice_does_not_expand_depth()
+    {
+        $html = '<h2>A</h2><h3>B</h3><h4>C</h4>';
+
+        $once = (new Parser($html))->from('h2')->depth(2)->build();
+        $twice = (new Parser($html))->from('h2')->depth(2)->from('h2')->build();
+
+        $this->assertEquals(count($once), count($twice));
+        $this->assertEquals(count($once[0]['children']), count($twice[0]['children']));
+    }
+}

--- a/tests/Unit/ParserSafetyTest.php
+++ b/tests/Unit/ParserSafetyTest.php
@@ -7,7 +7,6 @@ use Goldnead\StatamicToc\Tests\TestCase;
 
 class ParserSafetyTest extends TestCase
 {
-    /** @test */
     public function test_handles_heading_with_missing_attrs()
     {
         $content = [
@@ -24,7 +23,6 @@ class ParserSafetyTest extends TestCase
         $this->assertEquals(0, $result['total_results']);
     }
 
-    /** @test */
     public function test_handles_heading_with_missing_content()
     {
         $content = [
@@ -41,7 +39,6 @@ class ParserSafetyTest extends TestCase
         $this->assertEquals(0, $result['total_results']);
     }
 
-    /** @test */
     public function test_handles_heading_with_empty_content_array()
     {
         $content = [
@@ -58,7 +55,6 @@ class ParserSafetyTest extends TestCase
         $this->assertEquals(0, $result['total_results']);
     }
 
-    /** @test */
     public function test_handles_items_missing_type_key()
     {
         $content = [
@@ -77,7 +73,6 @@ class ParserSafetyTest extends TestCase
         $this->assertEquals(1, $result[0]['total_results']);
     }
 
-    /** @test */
     public function test_handles_content_first_element_not_array()
     {
         $content = [
@@ -94,7 +89,6 @@ class ParserSafetyTest extends TestCase
         $this->assertEquals(0, $result['total_results']);
     }
 
-    /** @test */
     public function test_handles_scalar_content()
     {
         // A malformed Bard node whose 'content' is a scalar (e.g. an int)
@@ -113,7 +107,6 @@ class ParserSafetyTest extends TestCase
         $this->assertEquals(0, $result['total_results']);
     }
 
-    /** @test */
     public function test_handles_non_numeric_level()
     {
         $content = [
@@ -130,7 +123,6 @@ class ParserSafetyTest extends TestCase
         $this->assertEquals(0, $result['total_results']);
     }
 
-    /** @test */
     public function test_handles_content_first_element_missing_text_key()
     {
         $content = [
@@ -147,7 +139,6 @@ class ParserSafetyTest extends TestCase
         $this->assertEquals(0, $result['total_results']);
     }
 
-    /** @test */
     public function test_from_preserves_depth_when_minlevel_changes()
     {
         // depth(2) from h2 should only include h2 and h3, not h4
@@ -162,7 +153,6 @@ class ParserSafetyTest extends TestCase
         $this->assertEmpty($result[0]['children'][0]['children'] ?? []);
     }
 
-    /** @test */
     public function test_from_called_twice_does_not_expand_depth()
     {
         $html = '<h2>A</h2><h3>B</h3><h4>C</h4>';

--- a/tests/Unit/ParserTest.php
+++ b/tests/Unit/ParserTest.php
@@ -142,9 +142,11 @@ class ParserTest extends TestCase
         if (isset($child['is_root'])) {
             $this->assertIsBool($child['is_root']);
         }
-        if (isset($child['has_hildren'])) {
-            $this->assertIsBool($child['has_hildren']);
-            $this->assertIsInt($child['total_children']);
+        if (isset($child['has_children'])) {
+            $this->assertIsBool($child['has_children']);
+            if ($child['has_children']) {
+                $this->assertIsInt($child['total_children']);
+            }
         }
         if ($child['level'] > 1) {
             $this->assertIsInt($child['parent']);

--- a/tests/Unit/ParserTest.php
+++ b/tests/Unit/ParserTest.php
@@ -9,7 +9,6 @@ class ParserTest extends TestCase
 {
     public $parser;
 
-    /** @test */
     public function test_can_detect_html()
     {
         $html = $this->fakeHTMLContent(2, 3);
@@ -21,7 +20,6 @@ class ParserTest extends TestCase
         $this->assertFalse($parser->isHTML($markdown));
     }
 
-    /** @test */
     public function test_can_detect_markdown()
     {
         $markdown = $this->fakeMarkdownContent(2, 3);
@@ -33,7 +31,6 @@ class ParserTest extends TestCase
         $this->assertFalse($parser->isMarkdown($html));
     }
 
-    /** @test */
     public function test_can_build_toc_tree_from_markdown()
     {
         $markdown = $this->fakeMarkdownContent(4, 3);
@@ -47,7 +44,6 @@ class ParserTest extends TestCase
         $this->assertEquals(1, count($tree[0]['children'][1]['children']));
     }
 
-    /** @test */
     public function test_can_create_toc_tree()
     {
         $html = $this->fakeHTMLContent(4, 3);
@@ -61,7 +57,6 @@ class ParserTest extends TestCase
         $this->assertEquals(1, count($tree[0]['children'][1]['children']));
     }
 
-    /** @test */
     public function test_can_flatten_toc_tree()
     {
         $html = $this->fakeHTMLContent(4, 3);
@@ -72,7 +67,6 @@ class ParserTest extends TestCase
         $this->assertEquals(5, count($tree));
     }
 
-    /** @test */
     public function test_can_flatten_toc_tree_with_depth()
     {
         $html = $this->fakeHTMLContent(4, 3);
@@ -83,8 +77,7 @@ class ParserTest extends TestCase
         $this->assertEquals(3, count($tree));
     }
 
-    /** @test */
-    public function can_build_tree_from_html()
+    public function test_can_build_tree_from_html()
     {
         $html = $this->fakeHTMLContent(4, 3);
         $html .= $this->fakeHTMLContent(2, 3, true, false);
@@ -97,7 +90,6 @@ class ParserTest extends TestCase
         $this->assertEquals(1, count($tree[0]['children'][1]['children']));
     }
 
-    /** @test */
     public function test_can_build_tree_from_bard()
     {
         $content = array_merge($this->fakeBardArray(4, 3), $this->fakeBardArray(2, 3, true, false));
@@ -110,7 +102,6 @@ class ParserTest extends TestCase
         $this->assertEquals(1, count($tree[0]['children'][1]['children']));
     }
 
-    /** @test */
     public function test_contains_total_results_and_no_results()
     {
         $html = $this->fakeHTMLContent(4, 3);
@@ -125,7 +116,6 @@ class ParserTest extends TestCase
         $this->assertEquals(true, $tree['no_results']);
     }
 
-    /** @test */
     public function test_array_tree_format_is_correct()
     {
         $content = array_merge($this->fakeBardArray(4, 3), $this->fakeBardArray(2, 3, true, false));
@@ -161,7 +151,6 @@ class ParserTest extends TestCase
         }
     }
 
-    /** @test */
     public function test_can_generate_ids()
     {
         $html = $this->fakeHTMLContent(4, 3);

--- a/tests/Unit/RecursionTest.php
+++ b/tests/Unit/RecursionTest.php
@@ -19,7 +19,7 @@ class RecursionTest extends TestCase
     }
 
     /** @test */
-    public function when_true_renders_toc()
+    public function test_when_true_renders_toc()
     {
         $this->tag->setParameters([
             'content' => '<h1>Heading 1</h1><h2>Heading 2</h2>',
@@ -32,7 +32,7 @@ class RecursionTest extends TestCase
     }
 
     /** @test */
-    public function when_false_suppresses_toc()
+    public function test_when_false_suppresses_toc()
     {
         $this->tag->setParameters([
             'content' => '<h1>Heading 1</h1><h2>Heading 2</h2>',
@@ -43,7 +43,7 @@ class RecursionTest extends TestCase
     }
 
     /** @test */
-    public function when_string_false_suppresses_toc()
+    public function test_when_string_false_suppresses_toc()
     {
         $this->tag->setParameters([
             'content' => '<h1>Heading 1</h1><h2>Heading 2</h2>',
@@ -54,7 +54,7 @@ class RecursionTest extends TestCase
     }
 
     /** @test */
-    public function when_string_true_renders_toc()
+    public function test_when_string_true_renders_toc()
     {
         $this->tag->setParameters([
             'content' => '<h1>Heading 1</h1><h2>Heading 2</h2>',

--- a/tests/Unit/RecursionTest.php
+++ b/tests/Unit/RecursionTest.php
@@ -18,7 +18,6 @@ class RecursionTest extends TestCase
             ->setContext([]);
     }
 
-    /** @test */
     public function test_when_true_renders_toc()
     {
         $this->tag->setParameters([
@@ -31,7 +30,6 @@ class RecursionTest extends TestCase
         $this->assertEquals('Heading 1', $output[0]['toc_title']);
     }
 
-    /** @test */
     public function test_when_false_suppresses_toc()
     {
         $this->tag->setParameters([
@@ -42,7 +40,6 @@ class RecursionTest extends TestCase
         $this->assertSame([], $this->tag->index());
     }
 
-    /** @test */
     public function test_when_string_false_suppresses_toc()
     {
         $this->tag->setParameters([
@@ -53,7 +50,6 @@ class RecursionTest extends TestCase
         $this->assertSame([], $this->tag->index());
     }
 
-    /** @test */
     public function test_when_string_true_renders_toc()
     {
         $this->tag->setParameters([

--- a/tests/Unit/TagTest.php
+++ b/tests/Unit/TagTest.php
@@ -20,7 +20,6 @@ class TagTest extends TestCase
       ->setContext([]);
   }
 
-  /** @test */
   public function test_when_false_returns_empty_array()
   {
     $this->tag->setParameters([
@@ -30,7 +29,6 @@ class TagTest extends TestCase
     $this->assertSame([], $this->tag->index());
   }
 
-  /** @test */
   public function test_when_string_false_returns_empty_array()
   {
     // Antlers dynamic binding (:when="$condition") can deliver the value as
@@ -42,7 +40,6 @@ class TagTest extends TestCase
     $this->assertSame([], $this->tag->index());
   }
 
-  /** @test */
   public function test_when_true_outputs_items()
   {
     $this->tag->setParameters([
@@ -52,7 +49,6 @@ class TagTest extends TestCase
     $this->assertNotEmpty($this->tag->index());
   }
 
-  /** @test */
   public function test_when_string_true_outputs_items()
   {
     $this->tag->setParameters([
@@ -62,7 +58,6 @@ class TagTest extends TestCase
     $this->assertNotEmpty($this->tag->index());
   }
 
-  /** @test */
   public function test_when_omitted_outputs_items()
   {
     $this->tag->setParameters([
@@ -71,7 +66,6 @@ class TagTest extends TestCase
     $this->assertNotEmpty($this->tag->index());
   }
 
-  /** @test */
   public function test_tag_outputs_array()
   {
     $this->tag->setParameters([
@@ -82,7 +76,6 @@ class TagTest extends TestCase
     $this->assertIsArray($output);
   }
 
-  /** @test */
   public function test_tag_outputs_correct_number_of_items()
   {
     $this->tag->setParameters([
@@ -93,7 +86,6 @@ class TagTest extends TestCase
     $this->assertEquals($this->countChildren($output), 3);
   }
 
-  /** @test */
   public function test_tag_outputs_array_with_correct_number_of_items_when_flat()
   {
     $this->tag->setParameters([
@@ -104,7 +96,6 @@ class TagTest extends TestCase
     $this->assertEquals($this->countChildren($output), 3);
   }
 
-  /** @test */
   public function test_tag_outputs_array_with_correct_number_of_items_when_not_flat()
   {
     $this->tag->setParameters([
@@ -114,7 +105,6 @@ class TagTest extends TestCase
     $this->assertEquals($this->countChildren($output), 3);
   }
 
-  /** @test */
   public function test_tag_outputs_array_with_correct_number_of_items_when_not_flat_and_depth_is_set()
   {
     $this->tag->setParameters([
@@ -125,7 +115,6 @@ class TagTest extends TestCase
     $this->assertEquals($this->countChildren($output), 2);
   }
 
-  /** @test */
   public function test_tag_outputs_array_with_correct_number_of_items_when_not_flat_and_depth_is_set_and_from_is_set()
   {
     $this->tag->setParameters([
@@ -137,7 +126,6 @@ class TagTest extends TestCase
     $this->assertEquals($this->countChildren($output), 2);
   }
 
-  /** @test */
   public function test_tag_outputs_array_with_correct_number_of_items_when_not_flat_and_depth_is_set_and_from_is_set_and_field_is_set()
   {
     $this->tag->setParameters([
@@ -155,7 +143,6 @@ class TagTest extends TestCase
     $this->assertEquals($this->countChildren($output), 2);
   }
 
-  /** @test */
   public function test_tag_outputs_array_with_correct_number_of_items_when_not_flat_and_depth_is_set_and_from_is_set_and_field_is_set_and_content_is_set()
   {
     $this->tag->setParameters([
@@ -174,7 +161,6 @@ class TagTest extends TestCase
     $this->assertEquals($this->countChildren($output), 2);
   }
 
-  /** @test */
   public function test_tag_outputs_array_with_correct_number_of_items_when_not_flat_and_depth_is_set_and_from_is_set_and_field_is_set_and_content_is_set_and_is_flat_is_set()
   {
     $this->tag->setParameters([
@@ -194,7 +180,6 @@ class TagTest extends TestCase
     $this->assertEquals($this->countChildren($output), 2);
   }
 
-  /** @test */
   public function test_tag_outputs_array_with_correct_number_of_items_when_not_flat_and_depth_is_set_and_from_is_set_and_field_is_set_and_content_is_set_and_is_flat_is_set_and_from_is_set()
   {
     $this->tag->setParameters([

--- a/tests/Unit/TagTest.php
+++ b/tests/Unit/TagTest.php
@@ -21,7 +21,7 @@ class TagTest extends TestCase
   }
 
   /** @test */
-  public function when_false_returns_empty_array()
+  public function test_when_false_returns_empty_array()
   {
     $this->tag->setParameters([
       'content' => $this->fakeHTMLContent(2, 3),
@@ -31,7 +31,7 @@ class TagTest extends TestCase
   }
 
   /** @test */
-  public function when_string_false_returns_empty_array()
+  public function test_when_string_false_returns_empty_array()
   {
     // Antlers dynamic binding (:when="$condition") can deliver the value as
     // the string "false" rather than a boolean — this was the bug in issue #28.
@@ -43,7 +43,7 @@ class TagTest extends TestCase
   }
 
   /** @test */
-  public function when_true_outputs_items()
+  public function test_when_true_outputs_items()
   {
     $this->tag->setParameters([
       'content' => $this->fakeHTMLContent(2, 3),
@@ -53,7 +53,7 @@ class TagTest extends TestCase
   }
 
   /** @test */
-  public function when_string_true_outputs_items()
+  public function test_when_string_true_outputs_items()
   {
     $this->tag->setParameters([
       'content' => $this->fakeHTMLContent(2, 3),
@@ -63,7 +63,7 @@ class TagTest extends TestCase
   }
 
   /** @test */
-  public function when_omitted_outputs_items()
+  public function test_when_omitted_outputs_items()
   {
     $this->tag->setParameters([
       'content' => $this->fakeHTMLContent(2, 3),
@@ -72,7 +72,7 @@ class TagTest extends TestCase
   }
 
   /** @test */
-  public function tag_outputs_array()
+  public function test_tag_outputs_array()
   {
     $this->tag->setParameters([
       'content' => $this->fakeHTMLContent(2, 3),
@@ -83,7 +83,7 @@ class TagTest extends TestCase
   }
 
   /** @test */
-  public function tag_outputs_correct_number_of_items()
+  public function test_tag_outputs_correct_number_of_items()
   {
     $this->tag->setParameters([
       'content' => $this->fakeBardArray(2, 3),
@@ -94,7 +94,7 @@ class TagTest extends TestCase
   }
 
   /** @test */
-  public function tag_outputs_array_with_correct_number_of_items_when_flat()
+  public function test_tag_outputs_array_with_correct_number_of_items_when_flat()
   {
     $this->tag->setParameters([
       'content' => $this->fakeHTMLContent(2, 3),
@@ -105,7 +105,7 @@ class TagTest extends TestCase
   }
 
   /** @test */
-  public function tag_outputs_array_with_correct_number_of_items_when_not_flat()
+  public function test_tag_outputs_array_with_correct_number_of_items_when_not_flat()
   {
     $this->tag->setParameters([
       'content' => $this->fakeHTMLContent(2, 3),
@@ -115,7 +115,7 @@ class TagTest extends TestCase
   }
 
   /** @test */
-  public function tag_outputs_array_with_correct_number_of_items_when_not_flat_and_depth_is_set()
+  public function test_tag_outputs_array_with_correct_number_of_items_when_not_flat_and_depth_is_set()
   {
     $this->tag->setParameters([
       'content' => $this->fakeBardArray(3, 6, false),
@@ -126,7 +126,7 @@ class TagTest extends TestCase
   }
 
   /** @test */
-  public function tag_outputs_array_with_correct_number_of_items_when_not_flat_and_depth_is_set_and_from_is_set()
+  public function test_tag_outputs_array_with_correct_number_of_items_when_not_flat_and_depth_is_set_and_from_is_set()
   {
     $this->tag->setParameters([
       'content' => $this->fakeHTMLContent(3, 6, false),
@@ -138,7 +138,7 @@ class TagTest extends TestCase
   }
 
   /** @test */
-  public function tag_outputs_array_with_correct_number_of_items_when_not_flat_and_depth_is_set_and_from_is_set_and_field_is_set()
+  public function test_tag_outputs_array_with_correct_number_of_items_when_not_flat_and_depth_is_set_and_from_is_set_and_field_is_set()
   {
     $this->tag->setParameters([
       "depth" => 2,
@@ -156,7 +156,7 @@ class TagTest extends TestCase
   }
 
   /** @test */
-  public function tag_outputs_array_with_correct_number_of_items_when_not_flat_and_depth_is_set_and_from_is_set_and_field_is_set_and_content_is_set()
+  public function test_tag_outputs_array_with_correct_number_of_items_when_not_flat_and_depth_is_set_and_from_is_set_and_field_is_set_and_content_is_set()
   {
     $this->tag->setParameters([
       "depth" => 2,
@@ -175,7 +175,7 @@ class TagTest extends TestCase
   }
 
   /** @test */
-  public function tag_outputs_array_with_correct_number_of_items_when_not_flat_and_depth_is_set_and_from_is_set_and_field_is_set_and_content_is_set_and_is_flat_is_set()
+  public function test_tag_outputs_array_with_correct_number_of_items_when_not_flat_and_depth_is_set_and_from_is_set_and_field_is_set_and_content_is_set_and_is_flat_is_set()
   {
     $this->tag->setParameters([
       "depth" => 2,
@@ -195,7 +195,7 @@ class TagTest extends TestCase
   }
 
   /** @test */
-  public function tag_outputs_array_with_correct_number_of_items_when_not_flat_and_depth_is_set_and_from_is_set_and_field_is_set_and_content_is_set_and_is_flat_is_set_and_from_is_set()
+  public function test_tag_outputs_array_with_correct_number_of_items_when_not_flat_and_depth_is_set_and_from_is_set_and_field_is_set_and_content_is_set_and_is_flat_is_set_and_from_is_set()
   {
     $this->tag->setParameters([
       "depth" => 2,


### PR DESCRIPTION
Führt die beiden offenen Bugfix-PRs zusammen. Ersetzt #33 und #34.

## Warum zusammengeführt und nicht nacheinander gemerged

#34 ist für `Parser.php` inhaltlich ein Superset von #33, mit einer Ausnahme: Es lässt den Skalar-Guard fallen, den #33 abgedeckt hat. `normalizeHeadingText()` ist als `array $content` typisiert, ein Bard-Knoten mit `'content' => 123` wirft damit einen `TypeError`, statt übersprungen zu werden. Gegen den Branch von #34 nachgestellt:

```
TypeError: Parser::normalizeHeadingText(): Argument #1 ($content) must be of type array, int given
```

Der Test aus #33 ist wieder drin, dazu einer für nicht-numerische Level.

## Inhalt

- Rekursiver Bard-Scan: Überschriften in verschachtelten Sets (Spalten, Grids, Replicator) werden gefunden
- Überschriften mit Inline-Formatierung behalten ihren vollen Text (#26). Vorher fiel eine Überschrift, die mit fett/kursiv/Link beginnt, komplett aus der Liste, und eine mit Formatierung in der Mitte wurde abgeschnitten
- `exclude`-Parameter am Tag: kommaseparierte Titel oder Regex
- `from()` weitet die Level-Spanne nicht mehr auf, wenn es nach `depth()` oder zweimal aufgerufen wird
- Guards für fehlende `attrs`, fehlenden/skalaren `content` und nicht-numerische Level

## Zwei Ergänzungen über die PRs hinaus

- Die Skalar-Toleranz oben
- `ModifierTest`, `RecursionTest` und `TagTest` liefen unter PHPUnit 12 **gar nicht**: Doc-Comment-Annotationen werden dort nicht mehr gelesen, und die Methoden hießen `modifier_outputs_string()` statt `test_...`. PHPUnit meldet das nur als Warnung, deshalb ist es nie aufgefallen. In der CI (PHPUnit 10/11) lief es noch, beim nächsten Testbench-Bump wäre es still ausgefallen. 21 Methoden umbenannt, Suite geht von 20 auf 41 Tests.

## Bewusst nicht drin

Der Starter-Kit-Partial und die README-Neufassung aus #34.

Der Partial benutzt `{{ toc:count }}` als Tag-Paar (`{{ toc:count }}...{{ /toc:count }}`), was der Tag nicht anbietet, verweist im Kommentar auf ein nicht existierendes `{{ toc:inject_ids }}` und hat keinen Test. Die README-Neufassung entfernt dokumentierte Variablen (`total_results`, `no_results`, `id`, `parent`) und das Blueprint-Beispiel und setzt einen Laravel-8.0-Badge, der nicht stimmt.

Stattdessen sind `exclude`, `when` und `toc:count` in der bestehenden README-Struktur nachdokumentiert.

## Testlauf

```
Tests: 41, Assertions: 106
```

PHP 8.5.5, Statamic 5.73.24, PHPUnit 12.5.33. Die zwei gemeldeten Deprecations kommen aus `orchestra/testbench` (`PDO::MYSQL_ATTR_SSL_CA` unter PHP 8.5), nicht aus dem Addon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)