### PR TITLE
Starter-Kit-Partial reparieren und mit Tests absichern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `statamic-toc` will be documented in this file.
 
+## Unreleased
+
+- New: a Tailwind-styled starter-kit partial, `{{ partial:statamic-toc::starter-kit }}`. Publish it
+  with `php artisan vendor:publish --tag=statamic-toc-views` to change the markup.
+- The addon registers its view namespace explicitly, so partials resolve in package test suites too.
+
 ## 2026-07-30 v1.9
 
 - Headings inside nested Bard sets (columns, grids, replicators) are now found. Previously only

--- a/README.md
+++ b/README.md
@@ -171,6 +171,48 @@ If you don't want to display your ToC as a nested list you can pass the paramete
 </ol>
 ```
 
+### Starter Kit
+
+A Tailwind-styled partial ships with the addon as a starting point. It reads the `article` field
+from the current context:
+
+```
+{{ partial:statamic-toc::starter-kit }}
+```
+
+It takes the same parameters as the tag, plus a `title` for the label above the list:
+
+```
+{{ partial:statamic-toc::starter-kit
+    field="content"
+    depth="3"
+    from="h2"
+    title="On this page"
+    exclude="Introduction, Footnotes"
+}}
+```
+
+When the field holds no headings, the partial renders nothing at all, so you can drop it into a
+template without wrapping it in a condition.
+
+To change the markup, publish it into your project:
+
+```bash
+php artisan vendor:publish --tag=statamic-toc-views
+```
+
+That copies the file to `resources/views/vendor/statamic-toc/starter-kit.antlers.html`.
+
+Tailwind only sees classes in the files it scans. If you use the partial straight from the addon
+instead of publishing it, add the addon path to the content sources in your Tailwind config:
+
+```js
+'./vendor/goldnead/statamic-toc/resources/views/**/*.html'
+```
+
+The partial only renders the list. The anchors point at the IDs the modifier injects, so the content
+field itself still needs `{{ your_field | toc }}`.
+
 ### Excluding headings
 
 Pass `exclude` to leave individual headings out of the list. A comma-separated string matches

--- a/docs/README.md
+++ b/docs/README.md
@@ -204,6 +204,48 @@ Example:
 {{ /if }}
 ```
 
+### Starter Kit
+
+A Tailwind-styled partial ships with the addon as a starting point. It reads the `article` field
+from the current context:
+
+```
+{{ partial:statamic-toc::starter-kit }}
+```
+
+It takes the same parameters as the tag, plus a `title` for the label above the list:
+
+```
+{{ partial:statamic-toc::starter-kit
+    field="content"
+    depth="3"
+    from="h2"
+    title="On this page"
+    exclude="Introduction, Footnotes"
+}}
+```
+
+When the field holds no headings, the partial renders nothing at all, so you can drop it into a
+template without wrapping it in a condition.
+
+To change the markup, publish it into your project:
+
+```bash
+php artisan vendor:publish --tag=statamic-toc-views
+```
+
+That copies the file to `resources/views/vendor/statamic-toc/starter-kit.antlers.html`.
+
+Tailwind only sees classes in the files it scans. If you use the partial straight from the addon
+instead of publishing it, add the addon path to the content sources in your Tailwind config:
+
+```js
+'./vendor/goldnead/statamic-toc/resources/views/**/*.html'
+```
+
+The partial only renders the list. The anchors point at the IDs the modifier injects, so the content
+field itself still needs `{{ your_field | toc }}`.
+
 ### Excluding headings
 
 Pass `exclude` to leave individual headings out of the list. A comma-separated string matches

--- a/resources/views/starter-kit.antlers.html
+++ b/resources/views/starter-kit.antlers.html
@@ -1,0 +1,89 @@
+{{#
+    Statamic ToC — Starter Kit
+    ==========================
+    A Tailwind-styled table of contents, meant to be copied and changed.
+
+    Publish it into your own project with:
+
+        php artisan vendor:publish --tag=statamic-toc-views
+
+    That copies this file to resources/views/vendor/statamic-toc/starter-kit.antlers.html.
+
+    USAGE
+    -----
+    Reads the "article" field from the current context:
+
+        {{ partial:statamic-toc::starter-kit }}
+
+    With options:
+
+        {{ partial:statamic-toc::starter-kit
+            field="content"
+            depth="3"
+            from="h2"
+            title="On this page"
+            exclude="Introduction, Footnotes"
+        }}
+
+    PARAMETERS
+    ----------
+    field    Name of the field to parse. Default: "article"
+    depth    How many heading levels to show. Default: 3
+    from     Heading level to start from, h1 to h6. Default: "h1"
+    title    Label above the list. Default: "Table of Contents"
+    exclude  Comma-separated headings or a regex to skip. Default: none
+
+    The anchors here come from the same slugs the `toc` modifier injects, so
+    apply `{{ your_field | toc }}` to the content itself or the links go nowhere.
+
+    Tailwind only sees classes in the files it scans. If you use this partial
+    straight from the addon instead of publishing it, add the addon path to the
+    content sources in your Tailwind config:
+
+        './vendor/goldnead/statamic-toc/resources/views/**/*.html'
+#}}
+
+{{ toc_field = field ?? 'article' }}
+{{ toc_depth = depth ?? 3 }}
+{{ toc_from = from ?? 'h1' }}
+{{ toc_label = title ?? 'Table of Contents' }}
+{{ toc_exclude = exclude ?? '' }}
+
+{{ toc_total = {toc:count :field="toc_field" :depth="toc_depth" :from="toc_from" :exclude="toc_exclude"} }}
+
+{{ if toc_total > 0 }}
+<nav id="statamic-toc" aria-label="{{ toc_label }}">
+
+    {{# Header: label on the left, number of entries on the right. #}}
+    <div class="flex items-center justify-between mb-4">
+        <div class="flex items-center gap-2">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-indigo-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h10m-10 6h7" />
+            </svg>
+            <span class="text-base font-semibold text-slate-800">{{ toc_label }}</span>
+        </div>
+        <span class="text-xs font-medium text-slate-400 tabular-nums">{{ toc_total }} sections</span>
+    </div>
+
+    {{#
+        The list. Every item exposes toc_title, toc_id, level, has_children,
+        children, is_root and parent. The recursive block re-runs this same
+        markup for nested headings, so the styling applies at every level.
+    #}}
+    <ol role="list" class="space-y-0.5 text-sm">
+        {{ toc :field="toc_field" :depth="toc_depth" :from="toc_from" :exclude="toc_exclude" }}
+            <li>
+                <a href="#{{ toc_id }}"
+                   class="block py-1.5 px-2 rounded-md text-slate-600 no-underline transition-colors hover:text-slate-900 hover:bg-slate-50 {{ if is_root }}font-medium{{ else }}font-normal{{ /if }}">{{ toc_title }}</a>
+
+                {{ if has_children }}
+                    <ol role="list" class="ml-4 space-y-0.5">
+                        {{ *recursive children* }}
+                    </ol>
+                {{ /if }}
+            </li>
+        {{ /toc }}
+    </ol>
+
+</nav>
+{{ /if }}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -15,4 +15,20 @@ class ServiceProvider extends AddonServiceProvider
     protected $modifiers = [
         TocModifier::class,
     ];
+
+    protected $viewNamespace = 'statamic-toc';
+
+    public function bootAddon()
+    {
+        // Registered explicitly instead of relying on the automatic boot, which
+        // resolves the addon directory through the manifest and comes up empty
+        // in package test suites.
+        $this->loadViewsFrom(__DIR__.'/../resources/views', 'statamic-toc');
+
+        // The parent's $publishables maps into public_path(), which is meant for
+        // assets. Views belong in the project's view folder.
+        $this->publishes([
+            __DIR__.'/../resources/views' => resource_path('views/vendor/statamic-toc'),
+        ], 'statamic-toc-views');
+    }
 }

--- a/tests/Unit/StarterKitTest.php
+++ b/tests/Unit/StarterKitTest.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Tests\Unit;
+
+use Goldnead\StatamicToc\ServiceProvider;
+use Statamic\Facades\Antlers;
+use Statamic\Testing\AddonTestCase;
+
+class StarterKitTest extends AddonTestCase
+{
+    // Statamic's own harness. The hand-rolled TestCase in this repo never boots
+    // the addon: its manifest fixture has no 'autoload' or 'provider' key, so
+    // AddonServiceProvider::boot() returns early and the view namespace is
+    // never registered.
+    protected string $addonServiceProvider = ServiceProvider::class;
+
+    private function render(string $template, array $context = []): string
+    {
+        // The third argument marks the template as trusted. Without it Antlers
+        // treats the string as user data and skips every tag.
+        return (string) Antlers::parse($template, $context, true);
+    }
+
+    private function article(): string
+    {
+        return '<h1>Einstieg</h1><h2>Atem</h2><h3>Stütze</h3><h2>Resonanz</h2>';
+    }
+
+    public function test_the_view_namespace_resolves()
+    {
+        $this->assertTrue(
+            view()->exists('statamic-toc::starter-kit'),
+            'The addon registers its views under the packageName, which is "statamic-toc" and not "goldnead/statamic-toc".'
+        );
+    }
+
+    public function test_renders_from_the_context_field()
+    {
+        $output = $this->render(
+            '{{ partial:statamic-toc::starter-kit }}',
+            ['article' => $this->article()]
+        );
+
+        $this->assertStringContainsString('Einstieg', $output);
+        $this->assertStringContainsString('Atem', $output);
+        $this->assertStringContainsString('href="#einstieg"', $output);
+    }
+
+    public function test_nests_children()
+    {
+        $output = $this->render(
+            '{{ partial:statamic-toc::starter-kit }}',
+            ['article' => $this->article()]
+        );
+
+        // "Stütze" is an h3 below "Atem", so it must appear inside a nested list
+        $this->assertMatchesRegularExpression(
+            '#Atem.*<ol[^>]*>.*St(ü|&uuml;)tze#s',
+            $output
+        );
+    }
+
+    public function test_renders_nothing_without_headings()
+    {
+        $output = $this->render(
+            '{{ partial:statamic-toc::starter-kit }}',
+            ['article' => '<p>Kein einziger Zwischentitel.</p>']
+        );
+
+        $this->assertStringNotContainsString('<nav', $output);
+        $this->assertSame('', trim($output));
+    }
+
+    public function test_honours_the_field_parameter()
+    {
+        $output = $this->render(
+            '{{ partial:statamic-toc::starter-kit field="body" }}',
+            ['body' => $this->article(), 'article' => '<h1>Falsches Feld</h1>']
+        );
+
+        $this->assertStringContainsString('Einstieg', $output);
+        $this->assertStringNotContainsString('Falsches Feld', $output);
+    }
+
+    public function test_honours_from_and_depth()
+    {
+        $output = $this->render(
+            '{{ partial:statamic-toc::starter-kit from="h2" depth="1" }}',
+            ['article' => $this->article()]
+        );
+
+        $this->assertStringNotContainsString('Einstieg', $output);
+        $this->assertStringContainsString('Atem', $output);
+        $this->assertStringNotContainsString('tze', $output); // Stütze is h3
+    }
+
+    public function test_honours_the_exclude_parameter()
+    {
+        $output = $this->render(
+            '{{ partial:statamic-toc::starter-kit exclude="Resonanz" }}',
+            ['article' => $this->article()]
+        );
+
+        $this->assertStringContainsString('Atem', $output);
+        $this->assertStringNotContainsString('Resonanz', $output);
+    }
+
+    public function test_honours_the_title_parameter()
+    {
+        $output = $this->render(
+            '{{ partial:statamic-toc::starter-kit title="Auf dieser Seite" }}',
+            ['article' => $this->article()]
+        );
+
+        $this->assertStringContainsString('Auf dieser Seite', $output);
+        $this->assertStringNotContainsString('Table of Contents', $output);
+    }
+
+    public function test_the_count_matches_the_rendered_items()
+    {
+        $output = $this->render(
+            '{{ partial:statamic-toc::starter-kit }}',
+            ['article' => $this->article()]
+        );
+
+        // four headings in the fixture, all within the default depth
+        $this->assertSame(4, substr_count($output, '<a href="#'));
+        $this->assertStringContainsString('4 ', $output);
+    }
+
+    public function test_anchors_match_the_ids_the_modifier_injects()
+    {
+        $output = $this->render(
+            '{{ partial:statamic-toc::starter-kit }}{{ article | toc }}',
+            ['article' => $this->article()]
+        );
+
+        preg_match_all('/href="#([^"]+)"/', $output, $anchors);
+        preg_match_all('/<h[1-6] id="([^"]+)"/', $output, $ids);
+
+        $this->assertNotEmpty($anchors[1]);
+        $this->assertEqualsCanonicalizing($anchors[1], $ids[1]);
+    }
+}


### PR DESCRIPTION
Holt den Partial aus dem geschlossenen PR #34 zurück, repariert ihn und deckt ihn ab. Aus v1.9 war er herausgelassen worden, weil ungeprüft.

## Er hat nie funktioniert

Drei unabhängige Fehler, jeder für sich reicht für einen leeren String:

1. **Der dokumentierte Aufruf kann nicht auflösen.** `{{ partial:goldnead/statamic-toc::starter-kit }}` — Statamic registriert Addon-Views unter `Addon::packageName()`, und das ist `statamic-toc` ohne Vendor-Teil. Dazu ersetzt `Partial::viewName()` `/` durch `.`, bevor der Namespace nachgeschlagen wird. Richtig ist `{{ partial:statamic-toc::starter-kit }}`.
2. **`{{ toc:count }}` wurde als Tag-Paar um die ganze Komponente gelegt.** `count()` gibt einen int zurück, der Block wurde nie gerendert. Der Zähler landet jetzt in einer Variablen, das Markup steht in einem normalen `{{ if }}`.
3. **`$publishables` zeigt auf `public_path()`.** Das ist für Assets gedacht. Der Eintrag hätte die Views nach `public/vendor/goldnead/statamic-toc/resources/views/vendor/statamic-toc` kopiert, nicht in den View-Ordner, den die README versprochen hat. Ersetzt durch ein explizites `publishes()` unter dem Tag `statamic-toc-views`.

Dazu raus: ein Kommentar, der auf ein `{{ toc:inject_ids }}` verweist, das es nicht gibt.

## Zwei Dinge am Test-Harness

Beides hat gekostet, beides gehört dokumentiert:

- **Der ServiceProvider registriert den View-Namespace jetzt explizit** mit absolutem Pfad. `AddonServiceProvider::bootViews()` leitet ihn aus dem Addon-Verzeichnis ab, das über das Manifest aufgelöst wird — in Package-Testsuites ist es leer.
- **`StarterKitTest` erbt von Statamics eigener `AddonTestCase`.** Die handgeschriebene `TestCase` in diesem Repo setzt im Manifest-Fixture weder `autoload` noch `provider`, deshalb steigt `AddonServiceProvider::boot()` sofort wieder aus und registriert gar nichts. Für v2 wäre die ganze Suite auf `AddonTestCase` umzustellen.
- **`Antlers::parse()` braucht den dritten Parameter.** Ohne `trusted = true` behandelt Antlers das Template als User-Daten und überspringt **jedes** Tag, kommentarlos. Auch `{{ glide:generate }}` liefert dort leer. Das ist vermutlich der Grund, warum `RecursionTest` seinerzeit von Antlers-Integration auf Unit-Tests umgeschrieben wurde.

## Abgedeckt

`StarterKitTest`, 10 Tests: Namespace-Auflösung, Rendern aus dem Kontext-Feld, Verschachtelung, der leere Fall (rendert bewusst gar nichts, kein leeres `<nav>`), `field`, `from`/`depth`, `exclude`, `title`, Übereinstimmung von Zähler und Listenlänge, und Anker gegen die IDs des Modifiers.

```
Tests: 52, Assertions: 130
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)