### PR TITLE
[v2] Vertragstest für Anker-IDs (rot, absichtlich)

### DIFF
--- a/tests/Unit/AnchorContractTest.php
+++ b/tests/Unit/AnchorContractTest.php
@@ -1,0 +1,191 @@
+<?php
+
+namespace Tests\Unit;
+
+use Goldnead\StatamicToc\ServiceProvider;
+use Statamic\Facades\Antlers;
+use Statamic\Testing\AddonTestCase;
+
+/**
+ * The contract this addon lives or dies by:
+ *
+ *   every anchor the {{ toc }} tag renders points at an id the {{ | toc }}
+ *   modifier actually injected, and every heading the modifier touches is
+ *   reachable.
+ *
+ * Nothing enforced it so far. Tag and modifier each run their own Parser with
+ * their own slug registry and agree only by coincidence, kept apart by the
+ * '-list' and '-text' suffixes in Parser::generateId(). Where the coincidence
+ * breaks, the table of contents links into the void.
+ *
+ * These tests describe the target state. They are expected to fail until the
+ * v2 rework puts both sides on one shared registry.
+ */
+class AnchorContractTest extends AddonTestCase
+{
+    protected string $addonServiceProvider = ServiceProvider::class;
+
+    /**
+     * Renders a template the way a real page does. The third argument marks it
+     * as trusted; without it Antlers treats the string as user data and
+     * silently skips every tag.
+     */
+    private function render(string $template, array $context = []): string
+    {
+        return (string) Antlers::parse($template, $context, true);
+    }
+
+    /**
+     * The anchors the list links to, in order.
+     */
+    private function anchors(string $html): array
+    {
+        preg_match_all('/href="#([^"]+)"/', $html, $m);
+
+        return $m[1];
+    }
+
+    /**
+     * The ids that actually exist on headings in the rendered content.
+     *
+     * Takes the first id per heading, the way an HTML parser does: when an
+     * element carries the same attribute twice, the first one wins and the rest
+     * are dropped. Matching the last one would paper over exactly the defect
+     * test_no_heading_carries_two_ids is about.
+     */
+    private function ids(string $html): array
+    {
+        preg_match_all('/<h[1-6]\b[^>]*>/i', $html, $tags);
+
+        return collect($tags[0])
+            ->map(fn ($tag) => preg_match('/\bid="([^"]*)"/', $tag, $m) ? $m[1] : null)
+            ->filter()
+            ->values()
+            ->all();
+    }
+
+    /**
+     * The whole contract in one assertion: no anchor without a target, no
+     * heading without a way in.
+     */
+    private function assertAnchorsResolve(string $html, string $because)
+    {
+        $anchors = $this->anchors($html);
+        $ids = $this->ids($html);
+
+        $this->assertNotEmpty($anchors, 'The list rendered no anchors at all.');
+
+        $dangling = array_values(array_diff($anchors, $ids));
+        $this->assertSame([], $dangling, $because."\nAnchors without a matching heading id: ".implode(', ', $dangling));
+
+        $unreachable = array_values(array_diff($ids, $anchors));
+        $this->assertSame([], $unreachable, $because."\nHeadings the list cannot reach: ".implode(', ', $unreachable));
+    }
+
+    /**
+     * A page as a customer builds it: the list, then the content itself run
+     * through the modifier.
+     */
+    private const PAGE = '{{ toc :content="body" :from="from" :depth="depth" }}<a href="#{{ toc_id }}">{{ toc_title }}</a>{{ if children }}{{ *recursive children* }}{{ /if }}{{ /toc }}{{ body | toc }}';
+
+    private function page(string $body, string $from = 'h1', int $depth = 3): string
+    {
+        return $this->render(self::PAGE, compact('body', 'from', 'depth'));
+    }
+
+    public function test_the_simple_case_holds()
+    {
+        // The baseline. If this ever fails, the test itself is wrong.
+        $html = $this->page('<h1>Einstieg</h1><h2>Atem</h2><h3>Stütze</h3>');
+
+        $this->assertAnchorsResolve($html, 'Unique titles within the default depth must line up.');
+    }
+
+    public function test_duplicate_titles_line_up()
+    {
+        // Two headings with the same text. Both sides have to number them the
+        // same way, or the second link goes to the first heading.
+        $html = $this->page('<h2>Atem</h2><h3>Übung</h3><h2>Resonanz</h2><h3>Übung</h3>');
+
+        $this->assertAnchorsResolve($html, 'Repeated headings must get the same suffix on both sides.');
+    }
+
+    public function test_a_duplicate_above_the_starting_level_does_not_shift_the_numbering()
+    {
+        // With from="h2" the tag never sees the h1, but the modifier injects
+        // into it and counts it. From there the two registries disagree.
+        $html = $this->page('<h1>Atem</h1><h2>Atem</h2><h2>Resonanz</h2>', 'h2');
+
+        $this->assertAnchorsResolve($html, 'A skipped heading above `from` must not shift the anchors below it.');
+    }
+
+    public function test_headings_below_the_third_level_get_ids()
+    {
+        // from="h2" with depth 3 lists h2 to h4. The modifier builds its regex
+        // from a Parser that still sits at the default maxLevel of 3.
+        $html = $this->page('<h2>Atem</h2><h3>Stütze</h3><h4>Zwerchfell</h4>', 'h2');
+
+        $this->assertAnchorsResolve($html, 'Every level the list shows must also be injected.');
+    }
+
+    public function test_a_manual_anchor_wins_on_both_sides()
+    {
+        // Bard's anchor button and save_html both produce headings that already
+        // carry an id. That id is the anchor, and the list has to use it.
+        $html = $this->page('<h2 id="atemstuetze">Atem und Stütze</h2><h2>Resonanz</h2>');
+
+        $this->assertAnchorsResolve($html, 'A hand-written id is the anchor; the list must not slugify past it.');
+    }
+
+    public function test_no_heading_carries_two_ids()
+    {
+        // The guard in Parser::injectIds requires whitespace or '>' behind the
+        // closing quote, which never follows the last attribute. So an existing
+        // id is not detected and a second one is appended. The result is invalid
+        // HTML, and the browser keeps the first id, not the one the list links to.
+        $html = $this->page('<h2 id="atemstuetze">Atem und Stütze</h2>');
+
+        preg_match_all('/<h[1-6]\b[^>]*>/i', $html, $tags);
+
+        foreach ($tags[0] as $tag) {
+            $this->assertLessThan(
+                2,
+                preg_match_all('/\bid="/', $tag),
+                'A heading must not end up with two id attributes: '.$tag
+            );
+        }
+    }
+
+    public function test_two_fields_on_one_page_stay_independent()
+    {
+        // The modifier goes through a facade, and the facade caches its Parser
+        // for the whole request. The second call inherits the first registry.
+        $html = $this->render(
+            '{{ toc :content="one" }}<a href="#{{ toc_id }}">{{ toc_title }}</a>{{ /toc }}{{ one | toc }}'
+            .'{{ toc :content="two" }}<a href="#{{ toc_id }}">{{ toc_title }}</a>{{ /toc }}{{ two | toc }}',
+            ['one' => '<h2>Atem</h2>', 'two' => '<h2>Atem</h2>']
+        );
+
+        // Same title in both fields, so both sides must produce the same two
+        // ids in the same order.
+        $this->assertSame(
+            $this->anchors($html),
+            $this->ids($html),
+            'Two modifier calls in one request must not renumber each other.'
+        );
+    }
+
+    public function test_special_characters_survive_both_paths()
+    {
+        $html = $this->page('<h2>Öffnung &amp; Weite</h2><h3>Größe</h3>');
+
+        $this->assertAnchorsResolve($html, 'Umlauts and entities must slugify identically on both sides.');
+    }
+
+    public function test_formatted_headings_line_up()
+    {
+        $html = $this->page('<h2>Die <strong>Stütze</strong> im Chor</h2><h3>Übung</h3>');
+
+        $this->assertAnchorsResolve($html, 'Inline markup must not change the slug on one side only.');
+    }
+}


### PR DESCRIPTION
**Nicht mergen.** Dieser PR ist der Beweis für den Konstruktionsfehler, nicht seine Behebung. Die CI ist rot, und das ist der Punkt. Er bleibt offen, bis der v2-Umbau ihn grün macht.

## Der Vertrag

> Jeder Anker, den `{{ toc }}` rendert, zeigt auf eine ID, die `{{ | toc }}` tatsächlich injiziert hat, und jede Überschrift, die der Modifier anfasst, ist erreichbar.

Diesen Vertrag hat nie etwas geprüft. Tag und Modifier fahren je eine eigene `Parser`-Instanz mit eigener Slug-Registry und stimmen nur zufällig überein — auseinandergehalten durch die Suffixe `-list` und `-text` in `Parser::generateId()`.

## Fünf von neun Fällen fallen

| Fall | Befund |
|---|---|
| `from="h2"`, doppelter Titel darüber | Der Modifier zählt das h1 mit, das der Tag nie sieht. `atem-2` wird injiziert, aber nie verlinkt |
| h4 in Reichweite der Liste | Bekommt gar keine ID. `injectIds` baut sein Regex aus einem Parser, der beim Default `maxLevel = 3` steht |
| Handgesetzter Anker | Der Tag ignoriert ihn und slugifiziert den Titel |
| Doppelte `id`-Attribute | siehe unten |
| Zwei Modifier-Aufrufe pro Request | Nummerieren sich gegenseitig um, weil die Facade den Parser samt Registry cached |

Vier Fälle bestehen und sollen das auch: der einfache Fall, Dubletten innerhalb der Spanne, Umlaute und Entities, Inline-Markup in der Überschrift.

## Ein Befund, der schlimmer ist als gedacht

Im Konzept stand, der Modifier respektiere ein vorhandenes `id`. Tut er nur manchmal. Der Guard lautet:

```php
preg_match('/id=(["\'])(.*?)\1[\s>]/si', $matches[2], $matchedIds)
```

Er verlangt Whitespace oder `>` hinter dem schließenden Anführungszeichen. Auf das **letzte** Attribut folgt beides nicht, also bleibt ein vorhandenes `id` unentdeckt und ein zweites wird angehängt:

```
<h2 id="a">X</h2>              →  <h2 id="a" id="x" >X</h2>        zwei IDs
<h2 id="a" class="b">X</h2>    →  <h2 id="a" class="b">X</h2>      korrekt erkannt
<h2 class="b" id="a">X</h2>    →  <h2 class="b" id="a" id="x-2" >  zwei IDs
```

Das ist ungültiges HTML. Browser behalten die **erste** ID — und die Liste verlinkt die zweite. Jeder handgesetzte Anker aus dem Bard-Anchor-Button ist damit ein toter Link, nicht bloß ein inkonsistenter.

Der dritte Fall zeigt nebenbei den Registry-Fehler: `x-2` statt `x`, weil der Slug `x` im selben Request schon vergeben war.

## Zum Test selbst

`ids()` liest bewusst die **erste** ID pro Überschrift, so wie ein HTML-Parser es tut. Meine erste Fassung las durch ein gieriges `[^>]*` die letzte — damit bestand der Anker-Fall, obwohl das Markup kaputt war. Ein Vertragstest, der aus dem falschen Grund grün ist, ist schlimmer als keiner.

Gerendert wird über `Antlers::parse($tpl, $ctx, true)`. Ohne das dritte Argument behandelt Antlers das Template als User-Daten und überspringt kommentarlos jedes Tag.

Kontext: `TASKS/statamic-toc-v2-konzept.md`, Abschnitt 2 und Schritt 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)