### PR TITLE
[v2] Schritt 2: Extraktion aus dem Parser herauslösen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ All notable changes to `statamic-toc` will be documented in this file.
   with `php artisan vendor:publish --tag=statamic-toc-views` to change the markup.
 - The addon registers its view namespace explicitly, so partials resolve in package test suites too.
 
+## Unreleased (v2)
+
+- Requires PHP 8.2 and Statamic 5 or 6. Statamic 3 and 4 stay on the v1 line.
+- `league/commonmark` is a declared dependency instead of something the addon
+  hoped Statamic would bring along.
+- Heading extraction moved out of `Parser` into `Extractors/{Bard,Html,Markdown}`
+  behind one interface, chosen by an explicit `Detector`. Content is no longer
+  taken for markdown because it contains a `#`, and HTML without headings no
+  longer falls through the markdown branch.
+- Extractors report every heading at every level plus any id already on it.
+  Filtering by level moved to the caller, which is what lets the tag and the
+  modifier eventually share one set of headings.
+- Dropped `mb_convert_encoding(..., 'HTML-ENTITIES', ...)`, deprecated since
+  PHP 8.2, and `CommonMarkConverter::convertToHtml()`, deprecated in
+  league/commonmark 2.
+
 ## 2026-07-30 v1.9
 
 - Headings inside nested Bard sets (columns, grids, replicators) are now found. Previously only

--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,9 @@
     }
   ],
   "require": {
-    "php": "^7.4 | ^8.0 | ^8.1 | ^8.2",
-    "statamic/cms": "^3.0 | ^3.1 | ^3.2 | ^3.3 | ^3.4 | ^4.0 | ^5.0 | ^6.0"
+    "php": "^8.2",
+    "statamic/cms": "^5.0 | ^6.0",
+    "league/commonmark": "^2.0"
   },
   "require-dev": {
     "orchestra/testbench": "^5.0 | ^6.0 | ^7.0 | 8.x | 9.x",

--- a/src/Extractors/BardExtractor.php
+++ b/src/Extractors/BardExtractor.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Goldnead\StatamicToc\Extractors;
+
+use Goldnead\StatamicToc\Heading;
+
+class BardExtractor implements Extractor
+{
+    /** @var array<int, Heading> */
+    private array $headings = [];
+
+    public function extract(mixed $content): array
+    {
+        $this->headings = [];
+
+        if (is_array($content)) {
+            $this->walk($content);
+        }
+
+        return $this->headings;
+    }
+
+    /**
+     * Bard nests: sets hold nodes, nodes hold nodes. A flat scan of the top
+     * level misses every heading inside a two-column set or a replicator.
+     */
+    private function walk(mixed $items): void
+    {
+        if (! is_array($items)) {
+            return;
+        }
+
+        // A list of nodes rather than a single one.
+        if (array_key_exists(0, $items)) {
+            foreach ($items as $item) {
+                $this->walk($item);
+            }
+
+            return;
+        }
+
+        if (($items['type'] ?? null) === 'heading') {
+            $this->collect($items);
+        }
+
+        foreach ($items as $key => $value) {
+            if (! is_array($value)) {
+                continue;
+            }
+
+            // A node's own attrs hold no headings. A set's do.
+            if ($key === 'attrs' && ($items['type'] ?? null) !== 'set') {
+                continue;
+            }
+
+            $this->walk($value);
+        }
+    }
+
+    private function collect(array $node): void
+    {
+        $level = $node['attrs']['level'] ?? null;
+
+        if (! is_numeric($level)) {
+            return;
+        }
+
+        $content = $node['content'] ?? [];
+        $id = $node['attrs']['id'] ?? null;
+
+        $this->headings[] = new Heading(
+            title: is_array($content) ? $this->text($content) : '',
+            level: (int) $level,
+            explicitId: is_string($id) && trim($id) !== '' ? trim($id) : null,
+        );
+    }
+
+    /**
+     * A heading is a list of inline nodes. Reading only the first one drops
+     * everything behind a bold word and skips the heading entirely when it
+     * starts with one.
+     */
+    private function text(array $content): string
+    {
+        $text = '';
+
+        foreach ($content as $node) {
+            if (! is_array($node)) {
+                continue;
+            }
+
+            if (isset($node['text']) && is_scalar($node['text'])) {
+                $text .= $node['text'];
+            } elseif (isset($node['content']) && is_array($node['content'])) {
+                $text .= $this->text($node['content']);
+            }
+        }
+
+        return trim(preg_replace('/\s+/u', ' ', $text) ?? $text);
+    }
+}

--- a/src/Extractors/Detector.php
+++ b/src/Extractors/Detector.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Goldnead\StatamicToc\Extractors;
+
+class Detector
+{
+    /**
+     * An actual heading tag, not just any string that happens to contain "<h".
+     */
+    private const HTML_HEADING = '/<h[1-6]\b[^>]*>/i';
+
+    /**
+     * An ATX heading at the start of a line, or a setext underline. A stray "#"
+     * in a sentence or a hex colour is not markdown.
+     */
+    private const MARKDOWN_HEADING = '/^[ ]{0,3}#{1,6}[ \t]|^[^\n]+\n[ ]{0,3}(=+|-+)[ \t]*$/m';
+
+    public function for(mixed $content): Extractor
+    {
+        if ($this->isBard($content)) {
+            return new BardExtractor;
+        }
+
+        if ($this->isMarkdown($content)) {
+            return new MarkdownExtractor;
+        }
+
+        return new HtmlExtractor;
+    }
+
+    public function isBard(mixed $content): bool
+    {
+        return is_array($content);
+    }
+
+    public function isHtml(mixed $content): bool
+    {
+        return is_string($content) && preg_match(self::HTML_HEADING, $content) === 1;
+    }
+
+    public function isMarkdown(mixed $content): bool
+    {
+        if (! is_string($content) || $this->isHtml($content)) {
+            return false;
+        }
+
+        return preg_match(self::MARKDOWN_HEADING, $content) === 1;
+    }
+}

--- a/src/Extractors/Extractor.php
+++ b/src/Extractors/Extractor.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Goldnead\StatamicToc\Extractors;
+
+use Goldnead\StatamicToc\Heading;
+
+interface Extractor
+{
+    /**
+     * Every heading in the content, in document order, at every level.
+     *
+     * Extractors do not filter. Level ranges and exclusions are applied by the
+     * caller, because the modifier needs the complete set even when the list
+     * only shows part of it.
+     *
+     * @return array<int, Heading>
+     */
+    public function extract(mixed $content): array;
+}

--- a/src/Extractors/HtmlExtractor.php
+++ b/src/Extractors/HtmlExtractor.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Goldnead\StatamicToc\Extractors;
+
+use Goldnead\StatamicToc\Heading;
+
+class HtmlExtractor implements Extractor
+{
+    public function extract(mixed $content): array
+    {
+        if (! is_string($content) || trim($content) === '') {
+            return [];
+        }
+
+        $doc = $this->load($content);
+
+        if (! $doc) {
+            return [];
+        }
+
+        $headings = [];
+
+        foreach ((new \DOMXPath($doc))->query('//h1 | //h2 | //h3 | //h4 | //h5 | //h6') as $tag) {
+            $id = $tag instanceof \DOMElement && $tag->hasAttribute('id')
+                ? trim($tag->getAttribute('id'))
+                : null;
+
+            $headings[] = new Heading(
+                title: $this->normalize($tag->textContent),
+                level: (int) ltrim($tag->nodeName, 'hH'),
+                explicitId: $id === '' ? null : $id,
+            );
+        }
+
+        return $headings;
+    }
+
+    private function load(string $html): ?\DOMDocument
+    {
+        $doc = new \DOMDocument;
+
+        $previous = libxml_use_internal_errors(true);
+
+        // mb_convert_encoding($html, 'HTML-ENTITIES', 'UTF-8') was the old way
+        // of getting UTF-8 past libxml's Latin-1 assumption. It is deprecated
+        // since PHP 8.2; encoding non-ASCII as numeric entities is the
+        // documented replacement and DOM decodes them back on read.
+        $encoded = mb_encode_numericentity($html, [0x80, 0x10FFFF, 0, 0x1FFFFF], 'UTF-8');
+
+        $loaded = $doc->loadHTML(
+            '<!DOCTYPE html><html><body>'.$encoded.'</body></html>',
+            LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD
+        );
+
+        libxml_clear_errors();
+        libxml_use_internal_errors($previous);
+
+        return $loaded ? $doc : null;
+    }
+
+    private function normalize(string $text): string
+    {
+        // Collapse the whitespace a formatted heading spreads across its markup.
+        return trim(preg_replace('/\s+/u', ' ', $text) ?? $text);
+    }
+}

--- a/src/Extractors/MarkdownExtractor.php
+++ b/src/Extractors/MarkdownExtractor.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Goldnead\StatamicToc\Extractors;
+
+use League\CommonMark\CommonMarkConverter;
+
+class MarkdownExtractor implements Extractor
+{
+    public function __construct(private readonly HtmlExtractor $html = new HtmlExtractor) {}
+
+    public function extract(mixed $content): array
+    {
+        if (! is_string($content) || trim($content) === '') {
+            return [];
+        }
+
+        return $this->html->extract($this->toHtml($content));
+    }
+
+    private function toHtml(string $markdown): string
+    {
+        $converter = new CommonMarkConverter;
+
+        // convertToHtml() is deprecated in league/commonmark 2.x.
+        return method_exists($converter, 'convert')
+            ? (string) $converter->convert($markdown)
+            : (string) $converter->convertToHtml($markdown);
+    }
+}

--- a/src/Heading.php
+++ b/src/Heading.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Goldnead\StatamicToc;
+
+/**
+ * One heading as it was found in the content, before any slug is assigned.
+ *
+ * Extraction and anchoring are deliberately separate: an extractor reports what
+ * the document contains, a slugger decides what to call it. Only that split
+ * makes it possible for the tag and the modifier to work from one shared set of
+ * headings instead of computing ids twice.
+ */
+class Heading
+{
+    public function __construct(
+        public readonly string $title,
+        public readonly int $level,
+        /**
+         * An id that was already on the heading, from Bard's anchor button or
+         * from hand-written HTML. It wins over any generated slug.
+         */
+        public readonly ?string $explicitId = null,
+    ) {}
+
+    public function hasExplicitId(): bool
+    {
+        return $this->explicitId !== null && $this->explicitId !== '';
+    }
+
+    public function isEmpty(): bool
+    {
+        return $this->title === '';
+    }
+}

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -7,6 +7,7 @@
 
 namespace Goldnead\StatamicToc;
 
+use Goldnead\StatamicToc\Extractors\Detector;
 use Illuminate\Support\Str;
 
 class Parser
@@ -72,11 +73,7 @@ class Parser
      */
     public function isHTML(): bool
     {
-        if (! is_string($this->content)) {
-            return false;
-        }
-
-        return Str::contains($this->content, '<h');
+        return (new Detector)->isHtml($this->content);
     }
 
     /**
@@ -84,7 +81,7 @@ class Parser
      */
     public function isBard(): bool
     {
-        return is_array($this->content);
+        return (new Detector)->isBard($this->content);
     }
 
     /**
@@ -92,11 +89,7 @@ class Parser
      */
     public function isMarkdown(): bool
     {
-        if (! is_string($this->content)) {
-            return false;
-        }
-
-        return Str::contains($this->content, '#') && ! $this->isHTML();
+        return (new Detector)->isMarkdown($this->content);
     }
 
     /**
@@ -197,13 +190,9 @@ class Parser
 
     private function generate(): array
     {
-        if ($this->isHTML()) {
-            return $this->generateFromHtml();
-        } elseif ($this->isMarkdown()) {
-            return $this->generateFromMarkdown();
-        } else {
-            return $this->generateFromStructure();
-        }
+        return $this->assemble(
+            (new Detector)->for($this->content)->extract($this->content)
+        );
     }
 
     public function supplementExtraOutput(array $toc): array
@@ -228,83 +217,27 @@ class Parser
     }
 
     /**
-     * Parses a HTML-input and returns a fake bard-structure to be processed
-     * by $this->generateFromStructure().
+     * Turns the extracted headings into the array the tag renders: filtered to
+     * the requested level range, slugged, then linked up into a tree.
      */
-    private function generateFromHtml($content = null): array
+    private function assemble(array $extracted): array
     {
-        if (! $content) {
-            $content = $this->content;
+        foreach ($extracted as $heading) {
+            if ($heading->level < $this->minLevel || $heading->level > $this->maxLevel) {
+                continue;
+            }
+
+            if ($heading->isEmpty() || ! $this->shouldIncludeHeading($heading->title)) {
+                continue;
+            }
+
+            $this->headings[] = [
+                'toc_title' => $heading->title,
+                'level' => $heading->level,
+                'toc_id' => $this->generateId($heading->title, true),
+                'id' => count($this->headings) + 1,
+            ];
         }
-
-        // Erstellen Sie eine neue Instanz von DOMDocument
-        $doc = new \DOMDocument;
-
-        // Vermeiden von Warnungen bei fehlerhaftem HTML
-        libxml_use_internal_errors(true);
-
-        // Stellen Sie sicher, dass der Inhalt in UTF-8 kodiert ist
-        $content = mb_convert_encoding($content, 'HTML-ENTITIES', 'UTF-8');
-
-        // Laden Sie das HTML in das DOMDocument
-        $doc->loadHTML('<!DOCTYPE html><html><body>'.$content.'</body></html>', LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
-
-        // Bereinigen Sie die Fehler
-        libxml_clear_errors();
-
-        // Erstellen Sie eine XPath-Abfrage, um alle Überschriften in der richtigen Reihenfolge zu erhalten
-        $xpath = new \DOMXpath($doc);
-        $htags = $xpath->query('//h1 | //h2 | //h3 | //h4 | //h5 | //h6');
-
-        // Leere Sammlung für unsere Überschriften
-        $headings = collect([]);
-
-        // Iterieren Sie über jedes Tag und erstellen Sie ein Objekt ähnlich dem, das von Bard verwendet wird
-        foreach ($htags as $tag) {
-            $headings->push([
-                'type' => 'heading',
-                'attrs' => [
-                    'level' => (int) ltrim($tag->nodeName, 'h'),
-                ],
-                'content' => [
-                    [
-                        'type' => 'text',
-                        // Stellen Sie sicher, dass der Text in UTF-8 ist
-                        'text' => $tag->nodeValue,
-                    ],
-                ],
-            ]);
-        }
-
-        return $this->generateFromStructure($headings->toArray());
-    }
-
-    /**
-     * Parses a markdown-input and converts it to HTML to be processed
-     * by $this->generateFromHtml().
-     */
-    private function generateFromMarkdown(): array
-    {
-        $converter = new \League\CommonMark\CommonMarkConverter;
-        $html = $converter->convertToHtml($this->content);
-
-        return $this->generateFromHtml($html);
-    }
-
-    /**
-     * Generates an array of elements necessairy for the TOC-Tag to
-     * function.
-     */
-    private function generateFromStructure($structure = null): array
-    {
-        // create a collection with the content array
-        $raw = ! $structure ? $this->content : $structure;
-
-        if (! is_array($raw)) {
-            return [];
-        }
-
-        $this->collectHeadingsRecursively($raw);
 
         if (empty($this->headings)) {
             return [];
@@ -363,78 +296,6 @@ class Parser
 
         // return flat array if flag is true, nest it if not
         return $this->isFlat ? $this->headings : $this->nestHeadings();
-    }
-
-    /**
-     * Recursive function to collect headings from a Bard/Structure array.
-     */
-    private function collectHeadingsRecursively($items)
-    {
-        if (! is_array($items)) {
-            return;
-        }
-
-        // If it's a sequential array (a list of nodes or sets)
-        if (isset($items[0])) {
-            foreach ($items as $item) {
-                $this->collectHeadingsRecursively($item);
-            }
-
-            return;
-        }
-
-        // Processing a single node or set (keyed array)
-        if (isset($items['type']) && $items['type'] === 'heading') {
-            $level = $items['attrs']['level'] ?? 0;
-            if (is_numeric($level) && $level >= $this->minLevel && $level <= $this->maxLevel) {
-                // 'content' can be missing or a scalar on malformed Bard nodes.
-                $content = $items['content'] ?? [];
-                $title = is_array($content) ? $this->normalizeHeadingText($content) : '';
-
-                if ($title !== '' && $this->shouldIncludeHeading($title)) {
-                    $this->headings[] = [
-                        'toc_title' => $title,
-                        'level' => (int) $level,
-                        'toc_id' => $this->generateId($title, true),
-                        'id' => count($this->headings) + 1,
-                    ];
-                }
-            }
-        }
-
-        // Recurse into all properties that are arrays (except 'attrs' unless it's a set)
-        foreach ($items as $key => $value) {
-            if (! is_array($value)) {
-                continue;
-            }
-
-            if ($key === 'attrs' && isset($items['type']) && $items['type'] !== 'set') {
-                continue;
-            }
-
-            $this->collectHeadingsRecursively($value);
-        }
-    }
-
-    /**
-     * Normalizes heading text by concatenating all text segments.
-     */
-    private function normalizeHeadingText(array $content): string
-    {
-        $text = '';
-        foreach ($content as $node) {
-            if (! is_array($node)) {
-                continue;
-            }
-
-            if (isset($node['text']) && is_scalar($node['text'])) {
-                $text .= $node['text'];
-            } elseif (isset($node['content']) && is_array($node['content'])) {
-                $text .= $this->normalizeHeadingText($node['content']);
-            }
-        }
-
-        return trim($text);
     }
 
     /**

--- a/tests/Unit/ExtractionTest.php
+++ b/tests/Unit/ExtractionTest.php
@@ -1,0 +1,207 @@
+<?php
+
+namespace Tests\Unit;
+
+use Goldnead\StatamicToc\Extractors\BardExtractor;
+use Goldnead\StatamicToc\Extractors\Detector;
+use Goldnead\StatamicToc\Extractors\HtmlExtractor;
+use Goldnead\StatamicToc\Extractors\MarkdownExtractor;
+use Goldnead\StatamicToc\Tests\TestCase;
+
+class ExtractionTest extends TestCase
+{
+    private function titles(array $headings): array
+    {
+        return array_map(fn ($h) => $h->title, $headings);
+    }
+
+    private function levels(array $headings): array
+    {
+        return array_map(fn ($h) => $h->level, $headings);
+    }
+
+    // ---------------------------------------------------------------- Detector
+
+    public function test_detects_bard()
+    {
+        $this->assertTrue((new Detector)->isBard([['type' => 'heading']]));
+        $this->assertFalse((new Detector)->isBard('<h1>A</h1>'));
+    }
+
+    public function test_detects_html_by_an_actual_heading_tag()
+    {
+        $d = new Detector;
+
+        $this->assertTrue($d->isHtml('<h2>A</h2>'));
+        $this->assertTrue($d->isHtml('<h2 class="x">A</h2>'));
+        $this->assertFalse($d->isHtml('<p>A paragraph about <hr> and nothing else.</p>'));
+    }
+
+    public function test_a_hash_in_prose_is_not_markdown()
+    {
+        $d = new Detector;
+
+        // The old check was Str::contains($content, '#'), which turned any hex
+        // colour or hashtag into a markdown document.
+        $this->assertFalse($d->isMarkdown('<p>Our brand colour is #ff0000.</p>'));
+        $this->assertFalse($d->isMarkdown('Meet us at #chorfestival, it is worth it.'));
+        $this->assertTrue($d->isMarkdown("# Einstieg\n\nText."));
+        $this->assertTrue($d->isMarkdown("Einstieg\n========\n\nText."));
+    }
+
+    public function test_html_without_headings_is_not_markdown()
+    {
+        // It used to fall through to the markdown branch and get run through
+        // CommonMark, which is not what anyone asked for.
+        $this->assertFalse((new Detector)->isMarkdown('<p>Kein Zwischentitel.</p>'));
+    }
+
+    public function test_picks_the_matching_extractor()
+    {
+        $d = new Detector;
+
+        $this->assertInstanceOf(BardExtractor::class, $d->for([['type' => 'heading']]));
+        $this->assertInstanceOf(HtmlExtractor::class, $d->for('<h2>A</h2>'));
+        $this->assertInstanceOf(MarkdownExtractor::class, $d->for("## A\n"));
+    }
+
+    // ------------------------------------------------------------------- HTML
+
+    public function test_html_reads_every_level()
+    {
+        $headings = (new HtmlExtractor)->extract('<h1>A</h1><h4>B</h4><h6>C</h6>');
+
+        $this->assertSame(['A', 'B', 'C'], $this->titles($headings));
+        $this->assertSame([1, 4, 6], $this->levels($headings));
+    }
+
+    public function test_html_keeps_umlauts_intact()
+    {
+        // The old path went through mb_convert_encoding(..., 'HTML-ENTITIES'),
+        // deprecated since PHP 8.2.
+        $headings = (new HtmlExtractor)->extract('<h2>Größe und Stütze</h2><h2>Öffnung &amp; Weite</h2>');
+
+        $this->assertSame(['Größe und Stütze', 'Öffnung & Weite'], $this->titles($headings));
+    }
+
+    public function test_html_flattens_inline_markup()
+    {
+        $headings = (new HtmlExtractor)->extract('<h2>Die <strong>Stütze</strong> im <em>Chor</em></h2>');
+
+        $this->assertSame(['Die Stütze im Chor'], $this->titles($headings));
+    }
+
+    public function test_html_reports_an_existing_id()
+    {
+        $headings = (new HtmlExtractor)->extract('<h2 id="atemstuetze">Atem</h2><h2>Resonanz</h2>');
+
+        $this->assertTrue($headings[0]->hasExplicitId());
+        $this->assertSame('atemstuetze', $headings[0]->explicitId);
+        $this->assertFalse($headings[1]->hasExplicitId());
+    }
+
+    public function test_html_survives_broken_markup()
+    {
+        $headings = (new HtmlExtractor)->extract('<h2>Offen<h3>Verschachtelt</h2></h3><p>');
+
+        $this->assertNotEmpty($headings);
+    }
+
+    // ------------------------------------------------------------------- Bard
+
+    public function test_bard_finds_headings_in_nested_sets()
+    {
+        $content = [
+            ['type' => 'heading', 'attrs' => ['level' => 2], 'content' => [['type' => 'text', 'text' => 'Oben']]],
+            [
+                'type' => 'set',
+                'attrs' => [
+                    'values' => [
+                        'type' => 'columns',
+                        'left' => [
+                            ['type' => 'heading', 'attrs' => ['level' => 3], 'content' => [['type' => 'text', 'text' => 'Links']]],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->assertSame(['Oben', 'Links'], $this->titles((new BardExtractor)->extract($content)));
+    }
+
+    public function test_bard_concatenates_inline_nodes()
+    {
+        // A heading that starts with a mark used to be dropped completely, and
+        // one with a mark in the middle was cut short. That is issue #26.
+        $content = [[
+            'type' => 'heading',
+            'attrs' => ['level' => 2],
+            'content' => [
+                ['type' => 'text', 'marks' => [['type' => 'bold']], 'text' => 'Stütze'],
+                ['type' => 'text', 'text' => ' im Chor'],
+            ],
+        ]];
+
+        $this->assertSame(['Stütze im Chor'], $this->titles((new BardExtractor)->extract($content)));
+    }
+
+    public function test_bard_reports_an_anchor_from_attrs()
+    {
+        $content = [[
+            'type' => 'heading',
+            'attrs' => ['level' => 2, 'id' => 'atemstuetze'],
+            'content' => [['type' => 'text', 'text' => 'Atem']],
+        ]];
+
+        $this->assertSame('atemstuetze', (new BardExtractor)->extract($content)[0]->explicitId);
+    }
+
+    public function test_bard_skips_malformed_nodes_without_crashing()
+    {
+        $content = [
+            ['type' => 'heading', 'content' => [['type' => 'text', 'text' => 'Ohne attrs']]],
+            ['type' => 'heading', 'attrs' => ['level' => 2]],
+            ['type' => 'heading', 'attrs' => ['level' => 2], 'content' => 123],
+            ['type' => 'heading', 'attrs' => ['level' => 'zwei'], 'content' => [['type' => 'text', 'text' => 'X']]],
+            ['type' => 'heading', 'attrs' => ['level' => 2], 'content' => [['type' => 'text', 'text' => 'Heil']]],
+        ];
+
+        $headings = (new BardExtractor)->extract($content);
+
+        $this->assertSame(['', '', 'Heil'], $this->titles($headings));
+    }
+
+    // --------------------------------------------------------------- Markdown
+
+    public function test_markdown_reads_atx_and_setext()
+    {
+        $headings = (new MarkdownExtractor)->extract("# Einstieg\n\nText.\n\n## Atem\n\nUnterüberschrift\n----------------\n");
+
+        $this->assertSame(['Einstieg', 'Atem', 'Unterüberschrift'], $this->titles($headings));
+        $this->assertSame([1, 2, 2], $this->levels($headings));
+    }
+
+    public function test_markdown_ignores_a_hash_inside_a_code_block()
+    {
+        $headings = (new MarkdownExtractor)->extract("## Echt\n\n```\n# nur ein Kommentar\n```\n");
+
+        $this->assertSame(['Echt'], $this->titles($headings));
+    }
+
+    // ------------------------------------------------------- shared behaviour
+
+    public function test_extractors_do_not_filter_by_level()
+    {
+        // Filtering belongs to the caller. The modifier needs every heading,
+        // even the ones the list is not going to show.
+        $this->assertCount(6, (new HtmlExtractor)->extract('<h1>1</h1><h2>2</h2><h3>3</h3><h4>4</h4><h5>5</h5><h6>6</h6>'));
+    }
+
+    public function test_empty_input_yields_nothing()
+    {
+        $this->assertSame([], (new HtmlExtractor)->extract(''));
+        $this->assertSame([], (new HtmlExtractor)->extract(null));
+        $this->assertSame([], (new BardExtractor)->extract('not an array'));
+        $this->assertSame([], (new MarkdownExtractor)->extract('   '));
+    }
+}


### PR DESCRIPTION
Zweiter Schritt der v2-Umsetzung, Ziel-Branch `v2`. Trennt „welche Überschriften enthält dieses Dokument" von allem anderen. **Die Ausgabe des Tags ändert sich nicht**, alle 52 bestehenden Tests bleiben grün.

## Neu

- **`Heading`** — Value Object mit `title`, `level` und der ID, die im Quelltext schon stand. Die explizite ID wird erfasst, aber noch nicht verwendet; Schritt 3 reicht sie an den Slugger, damit ein handgesetzter Anker gegen einen generierten Slug gewinnt.
- **`Extractors/{Bard,Html,Markdown}Extractor`** hinter einem Interface, ausgewählt von `Detector`.

## Extractors filtern bewusst nicht

Sie melden jede Überschrift auf jeder Ebene. Die Level-Spanne, die Ausschlüsse und die Slugs wendet `Parser::assemble()` an.

Das ist die Voraussetzung für Schritt 3: Der Modifier braucht die vollständige Menge, auch wenn die Liste nur einen Teil zeigt. Genau daran scheitert heute der Fall `from="h2"` im Vertragstest.

## Erkennung statt Raten

| Vorher | Jetzt |
|---|---|
| `Str::contains($content, '<h')` | ein echtes `<h1>`…`<h6>`-Tag |
| `Str::contains($content, '#')` und kein HTML | ATX-Überschrift am Zeilenanfang oder Setext-Unterstrich |
| HTML ohne Überschriften fiel in den Markdown-Zweig | wird als HTML behandelt |

Ein Hex-Farbwert oder ein Hashtag im Fließtext hat bisher gereicht, um das ganze Feld durch CommonMark zu schicken.

## Zwei Deprecations raus

- `mb_convert_encoding($html, 'HTML-ENTITIES', 'UTF-8')`, seit PHP 8.2 deprecated, ersetzt durch `mb_encode_numericentity` — der dokumentierte Nachfolger.
- `CommonMarkConverter::convertToHtml()`, in league/commonmark 2 deprecated, mit Fallback für ältere Versionen.

`league/commonmark` ist jetzt eine deklarierte Abhängigkeit. Das Addon hat sie benutzt und darauf gehofft, dass Statamic sie mitbringt.

## Legacy

Laut Entscheidung vom 30.07. verlangt die v2-Linie PHP 8.2 und Statamic 5 oder 6. `composer.json` entsprechend angepasst. `main` bleibt auf der v1-Spanne und damit für v1.9.x-Hotfixes ausliefe­rbar.

## Vertragstest

Erwartungsgemäß unverändert rot, alle fünf Fälle. Extraktion allein repariert die Anker nicht — das ist Schritt 3. Sie liefert jetzt die explizite ID, die er dazu braucht.

```
Tests: 70, Assertions: 163
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)