### PR TITLE
fix(parser): Bard-Safety-Guard gegen objekt-attrs Crash (Nachzug aus #33)

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -385,7 +385,9 @@ class Parser
 
         // Processing a single node or set (keyed array)
         if (isset($items['type']) && $items['type'] === 'heading') {
-            $level = $items['attrs']['level'] ?? 0;
+            // 'attrs' can be an object (stdClass) on malformed Bard nodes; the
+            // null-coalesce does not protect against array access on an object.
+            $level = is_array($items['attrs'] ?? null) ? ($items['attrs']['level'] ?? 0) : 0;
             if (is_numeric($level) && $level >= $this->minLevel && $level <= $this->maxLevel) {
                 // 'content' can be missing or a scalar on malformed Bard nodes.
                 $content = $items['content'] ?? [];

--- a/tests/Unit/ParserSafetyTest.php
+++ b/tests/Unit/ParserSafetyTest.php
@@ -107,6 +107,29 @@ class ParserSafetyTest extends TestCase
         $this->assertEquals(0, $result['total_results']);
     }
 
+    public function test_handles_object_attrs()
+    {
+        // A malformed Bard node whose 'attrs' is an object (stdClass) instead
+        // of an array must not crash on the level access with "Cannot use
+        // object of type stdClass as array". The null-coalesce on
+        // $items['attrs']['level'] does not protect against this.
+        $attrs = new \stdClass;
+        $attrs->level = 2;
+
+        $content = [
+            [
+                'type' => 'heading',
+                'attrs' => $attrs,
+                'content' => [['type' => 'text', 'text' => 'Test']],
+            ],
+        ];
+
+        $result = (new Parser($content))->build();
+
+        $this->assertIsArray($result);
+        $this->assertEquals(0, $result['total_results']);
+    }
+
     public function test_handles_non_numeric_level()
     {
         $content = [


### PR DESCRIPTION
## Problem

`collectHeadingsRecursively()` liest `$items['attrs']['level'] ?? 0` (src/Parser.php:388). Bei einem malformed Bard-Node, dessen `attrs` ein Objekt (stdClass) statt Array ist, fatalt das mit `Cannot use object of type stdClass as array`. Der Null-Coalesce (`??`) schuetzt NICHT vor Array-Zugriff auf ein Objekt.

Reproduziert per `php -r` und rotem Test gegen die aktuelle v1.9-Struktur.

## Fix

`is_array()`-Absicherung vor dem verschachtelten Zugriff:
```php
$level = is_array($items['attrs'] ?? null) ? ($items['attrs']['level'] ?? 0) : 0;
```
Plus Regressionstest `test_handles_object_attrs`.

## Scope

Der skalar-/malformed-`content`-Pfad ist in v1.9 bereits abgesichert (`is_array($content)`-Check vor `normalizeHeadingText`, plus bestehender `test_handles_scalar_content`) und bleibt unangetastet. Nur der offene attrs-Pfad wird geguardet.

Nachzug aus #33, das nicht gemergt wurde (v1.9 entstand aus manuell zusammengefuehrtem #35). Kein CI-Change noetig: beide Matrix-Legs laufen bereits auf Laravel 12.

## Verifikation

- `test_handles_object_attrs`: rot (Fatal an Parser.php:388) -> gruen
- Volle Suite lokal gruen (53 Tests, 132 Assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)