### PR TITLE
[v2] Schritt 3: ein Anker-Vertrag für Tag und Modifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,17 @@ All notable changes to `statamic-toc` will be documented in this file.
 - Dropped `mb_convert_encoding(..., 'HTML-ENTITIES', ...)`, deprecated since
   PHP 8.2, and `CommonMarkConverter::convertToHtml()`, deprecated in
   league/commonmark 2.
+- The tag and the modifier now read their anchors from one shared registry
+  instead of each running its own slug pass. Four defects go away with it:
+  headings below the third level get ids; a `from` above a repeated heading no
+  longer shifts the anchors under it; a hand-written id is used by the list
+  instead of being slugged past; and two modifier calls on one page stop
+  renumbering each other.
+- A heading that already carries an id keeps exactly that one. The old check
+  missed an id in the last attribute position and appended a second, which is
+  invalid HTML and left the anchor pointing nowhere.
+- Excluding a heading from the list no longer changes the anchors of the
+  others.
 
 ## 2026-07-30 v1.9
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,12 @@ Then you get something like this:
 
 !> Note: When headings are duplicated, the ID is suffixed with a number preventing duplicated IDs which would be semantially wrong in HTML.
 
+If a heading already has an ID, from Bard's anchor button or from hand-written HTML, that ID is
+kept and the table of contents links to it. The modifier never adds a second one.
+
+The tag and the modifier take their IDs from the same place, so the list and the headings always
+agree, whatever `from`, `depth` or `exclude` are set to.
+
 ### The `toc` Tag
 
 You can use the `toc`-Tag like you would use any recursive tag (like the `nav` Tag) in your Antler-Templates:

--- a/src/Anchors/IdInjector.php
+++ b/src/Anchors/IdInjector.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Goldnead\StatamicToc\Anchors;
+
+/**
+ * Writes the anchors into the rendered HTML.
+ *
+ * Deliberately a targeted replacement of the opening heading tags rather than a
+ * round trip through DOMDocument, as the v2 sketch had it. This runs over
+ * published content: re-serialising a whole article would quietly rewrite
+ * markup nobody asked to change. Only `<h1>`..`<h6>` opening tags are touched,
+ * everything else stays byte for byte.
+ */
+class IdInjector
+{
+    /**
+     * @param  array<int, string|null>  $anchors  aligned by index with the
+     *                                            headings in the document
+     * @param  string|null  $attributes  extra attributes, where [id] is
+     *                                   replaced with the anchor
+     */
+    public function inject(string $html, array $anchors, ?string $attributes = null): string
+    {
+        $index = 0;
+
+        return preg_replace_callback(
+            '/<(h[1-6])((?:"[^"]*"|\'[^\']*\'|[^>"\'])*)>/i',
+            function ($matches) use ($anchors, $attributes, &$index) {
+                $tag = $matches[1];
+                $attrs = $matches[2];
+                $anchor = $anchors[$index] ?? null;
+                $index++;
+
+                // A heading that already carries an id keeps it. The old guard
+                // required whitespace or '>' behind the closing quote, which
+                // never follows the last attribute, so it appended a second id
+                // and produced invalid HTML.
+                if ($anchor === null || $this->hasId($attrs)) {
+                    return $matches[0];
+                }
+
+                $extra = $attributes ? ' '.str_replace('[id]', $anchor, $attributes) : '';
+
+                return sprintf('<%s%s id="%s"%s>', $tag, rtrim($attrs), $anchor, $extra);
+            },
+            $html
+        ) ?? $html;
+    }
+
+    private function hasId(string $attributes): bool
+    {
+        return preg_match('/\bid\s*=\s*(["\']).*?\1/i', $attributes) === 1;
+    }
+}

--- a/src/Anchors/Slugger.php
+++ b/src/Anchors/Slugger.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Goldnead\StatamicToc\Anchors;
+
+use Goldnead\StatamicToc\Heading;
+use Illuminate\Support\Str;
+
+/**
+ * Assigns one anchor per heading. The only place in the addon that decides what
+ * a heading is called.
+ */
+class Slugger
+{
+    /**
+     * Anchors for a whole document, aligned by index with the headings passed
+     * in. Headings without a usable title get null, so the injector leaves them
+     * alone rather than writing id="".
+     *
+     * @param  array<int, Heading>  $headings
+     * @return array<int, string|null>
+     */
+    public function assign(array $headings): array
+    {
+        $taken = [];
+        $anchors = [];
+
+        // Ids that were already in the document are claimed first, so a
+        // generated slug never collides with one of them, no matter where in
+        // the document it sits.
+        foreach ($headings as $heading) {
+            if ($heading->hasExplicitId()) {
+                $taken[$heading->explicitId] = true;
+            }
+        }
+
+        foreach ($headings as $heading) {
+            if ($heading->hasExplicitId()) {
+                $anchors[] = $heading->explicitId;
+
+                continue;
+            }
+
+            if ($heading->isEmpty()) {
+                $anchors[] = null;
+
+                continue;
+            }
+
+            $anchors[] = $this->unique(Str::slug($heading->title), $taken);
+        }
+
+        return $anchors;
+    }
+
+    /**
+     * Keeps counting until the slug is free. Checks the suffixed candidate
+     * against the same list, so an existing "atem-2" in the document cannot be
+     * handed out twice.
+     */
+    private function unique(string $slug, array &$taken): string
+    {
+        if ($slug === '') {
+            $slug = 'section';
+        }
+
+        $candidate = $slug;
+        $count = 2;
+
+        while (isset($taken[$candidate])) {
+            $candidate = $slug.'-'.$count;
+            $count++;
+        }
+
+        $taken[$candidate] = true;
+
+        return $candidate;
+    }
+}

--- a/src/Modifiers/Toc.php
+++ b/src/Modifiers/Toc.php
@@ -7,7 +7,9 @@
 
 namespace Goldnead\StatamicToc\Modifiers;
 
-use Goldnead\StatamicToc\Facades\ParserFacade as Parser;
+use Goldnead\StatamicToc\Anchors\IdInjector;
+use Goldnead\StatamicToc\Extractors\Detector;
+use Goldnead\StatamicToc\Registry;
 use Statamic\Modifiers\Modifier;
 
 class Toc extends Modifier
@@ -15,16 +17,29 @@ class Toc extends Modifier
     /**
      * Injects IDs into the DOM.
      *
+     * The anchors come from the shared registry, not from a second slug run of
+     * its own. That is the whole point: the tag and this modifier read the same
+     * decision, so an anchor cannot point at a heading that never got the id.
+     *
      * @param  mixed  $value    The value to be modified
      * @param  array  $params   Any parameters used in the modifier
      * @param  array  $context  Contextual values
      * @return mixed
      */
-    public function index($value, $params = [])
+    public function index($value, $params = [], $context = [])
     {
-        // initiate parser and let him inject ids into the DOM
-        $content = Parser::injectIds($value, empty($params) ? null : $params);
+        $html = (string) $value;
 
-        return $content;
+        if ($html === '') {
+            return $html;
+        }
+
+        $headings = (new Detector)->for($html)->extract($html);
+
+        return (new IdInjector)->inject(
+            $html,
+            app(Registry::class)->anchorsFor($headings),
+            empty($params) ? null : implode(' ', (array) $params)
+        );
     }
 }

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -7,14 +7,12 @@
 
 namespace Goldnead\StatamicToc;
 
+use Goldnead\StatamicToc\Anchors\IdInjector;
 use Goldnead\StatamicToc\Extractors\Detector;
-use Illuminate\Support\Str;
 
 class Parser
 {
     private $content;
-
-    private $slugs = [];
 
     private $maxLevel = 3;
 
@@ -33,8 +31,6 @@ class Parser
      */
     public function __construct($content = null)
     {
-        $this->slugs = collect($this->slugs);
-
         if ($content) {
             $this->setContent($content);
         }
@@ -61,7 +57,6 @@ class Parser
      */
     public function make($content)
     {
-        $this->slugs = collect();
         $this->headings = [];
         $this->content = $content;
 
@@ -190,9 +185,17 @@ class Parser
 
     private function generate(): array
     {
-        return $this->assemble(
-            (new Detector)->for($this->content)->extract($this->content)
-        );
+        $extracted = (new Detector)->for($this->content)->extract($this->content);
+
+        // Anchors are decided once per document, for every heading, and shared
+        // with the modifier. The level range only decides what the list shows,
+        // never what a heading is called.
+        return $this->assemble($extracted, $this->registry()->anchorsFor($extracted));
+    }
+
+    private function registry(): Registry
+    {
+        return app(Registry::class);
     }
 
     public function supplementExtraOutput(array $toc): array
@@ -220,9 +223,9 @@ class Parser
      * Turns the extracted headings into the array the tag renders: filtered to
      * the requested level range, slugged, then linked up into a tree.
      */
-    private function assemble(array $extracted): array
+    private function assemble(array $extracted, array $anchors): array
     {
-        foreach ($extracted as $heading) {
+        foreach ($extracted as $index => $heading) {
             if ($heading->level < $this->minLevel || $heading->level > $this->maxLevel) {
                 continue;
             }
@@ -231,10 +234,14 @@ class Parser
                 continue;
             }
 
+            if (($anchors[$index] ?? null) === null) {
+                continue;
+            }
+
             $this->headings[] = [
                 'toc_title' => $heading->title,
                 'level' => $heading->level,
-                'toc_id' => $this->generateId($heading->title, true),
+                'toc_id' => $anchors[$index],
                 'id' => count($this->headings) + 1,
             ];
         }
@@ -355,62 +362,26 @@ class Parser
     }
 
     /**
-     * Injects header HTML-Elements with thparamseir corersponding ids.
+     * Injects the anchors into a rendered HTML string.
+     *
+     * Kept as public API for anyone calling the parser directly. It no longer
+     * computes ids of its own: it looks up the anchors this document already
+     * got, so tag and modifier can never disagree.
      */
     public function injectIds($value, $params = null): string
     {
-        // Do all the regex magic here
-        $injected = preg_replace_callback(
-            '#<(h[1-'.$this->maxLevel.'])(.*?)>(.*?)</\1>#si',
-            // callback
-            function ($matches) use ($params) {
-                // the html tag
-                $tag = $matches[1];
-                // decode html entities to support special characters in headings/slug
-                $title = html_entity_decode(strip_tags($matches[3]));
-                $hasId = preg_match('/id=(["\'])(.*?)\1[\s>]/si', $matches[2], $matchedIds);
-                $id = $hasId ? $matchedIds[2] : $this->generateId($title, false);
-
-                if ($hasId) {
-                    return $matches[0];
-                }
-                if ($params && is_array($params)) {
-                    $params = implode(' ', $params);
-                } else {
-                    $params = '';
-                }
-
-                $params = str_replace('[id]', $id, $params);
-
-                // rebuild the tag with Id.
-                return sprintf('<%s%s id="%s" %s>%s</%s>', $tag, $matches[2], $id, $params, $matches[3], $tag);
-            },
-            $value
-        );
-
-        return $injected;
-    }
-
-    /**
-     * Slugifies a given title
-     *
-     * @return string [description]
-     */
-    private function generateId($title, $list = false): string
-    {
-        $id = $raw = Str::slug($title);
-        $count = 2;
-        $suffix = $list ? 'list' : 'text';
-
-        // make sure we don't have any duplicate ids via adding a counter at
-        // the end of an id if it already exists.
-        while ($this->slugs->contains($id.'-'.$suffix)) {
-            $id = $raw.'-'.$count;
-            $count++;
+        if (! is_string($value)) {
+            return (string) $value;
         }
 
-        $this->slugs->push($id.'-'.$suffix);
+        $extracted = (new Detector)->for($value)->extract($value);
 
-        return $id;
+        $attributes = is_array($params) ? implode(' ', $params) : $params;
+
+        return (new IdInjector)->inject(
+            $value,
+            app(Registry::class)->anchorsFor($extracted),
+            $attributes ?: null
+        );
     }
 }

--- a/src/Registry.php
+++ b/src/Registry.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Goldnead\StatamicToc;
+
+use Goldnead\StatamicToc\Anchors\Slugger;
+
+/**
+ * The one place anchors are decided, shared by the tag and the modifier for the
+ * length of a request.
+ *
+ * Keyed by the headings themselves, not by the raw content. The tag usually
+ * sees a Bard array while the modifier sees the rendered HTML of the same
+ * field: two very different strings describing the same sequence of headings.
+ * Hashing the levels and titles is what lets both sides land on the same entry.
+ */
+class Registry
+{
+    /** @var array<string, array<int, string|null>> */
+    private array $anchors = [];
+
+    public function __construct(private readonly Slugger $slugger = new Slugger) {}
+
+    /**
+     * Anchors for these headings, aligned by index. Computed once per document
+     * and per request.
+     *
+     * @param  array<int, Heading>  $headings
+     * @return array<int, string|null>
+     */
+    public function anchorsFor(array $headings): array
+    {
+        $key = $this->fingerprint($headings);
+
+        return $this->anchors[$key] ??= $this->slugger->assign($headings);
+    }
+
+    public function flush(): void
+    {
+        $this->anchors = [];
+    }
+
+    /**
+     * @param  array<int, Heading>  $headings
+     */
+    private function fingerprint(array $headings): string
+    {
+        return md5(implode("\n", array_map(
+            fn (Heading $h) => $h->level.'|'.$h->explicitId.'|'.$h->title,
+            $headings
+        )));
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -18,6 +18,15 @@ class ServiceProvider extends AddonServiceProvider
 
     protected $viewNamespace = 'statamic-toc';
 
+    public function register()
+    {
+        parent::register();
+
+        // One registry per request, so the tag and the modifier land on the
+        // same anchors for the same document.
+        $this->app->singleton(Registry::class);
+    }
+
     public function bootAddon()
     {
         // Registered explicitly instead of relying on the automatic boot, which

--- a/tests/Unit/AnchorContractTest.php
+++ b/tests/Unit/AnchorContractTest.php
@@ -1,0 +1,206 @@
+<?php
+
+namespace Tests\Unit;
+
+use Goldnead\StatamicToc\ServiceProvider;
+use Statamic\Facades\Antlers;
+use Statamic\Testing\AddonTestCase;
+
+/**
+ * The contract this addon lives or dies by:
+ *
+ *   every anchor the {{ toc }} tag renders points at an id the {{ | toc }}
+ *   modifier actually injected, and every heading the modifier touches is
+ *   reachable.
+ *
+ * Nothing enforced it so far. Tag and modifier each run their own Parser with
+ * their own slug registry and agree only by coincidence, kept apart by the
+ * '-list' and '-text' suffixes in Parser::generateId(). Where the coincidence
+ * breaks, the table of contents links into the void.
+ *
+ * These tests describe the target state. They are expected to fail until the
+ * v2 rework puts both sides on one shared registry.
+ */
+class AnchorContractTest extends AddonTestCase
+{
+    protected string $addonServiceProvider = ServiceProvider::class;
+
+    /**
+     * Renders a template the way a real page does. The third argument marks it
+     * as trusted; without it Antlers treats the string as user data and
+     * silently skips every tag.
+     */
+    private function render(string $template, array $context = []): string
+    {
+        return (string) Antlers::parse($template, $context, true);
+    }
+
+    /**
+     * The anchors the list links to, in order.
+     */
+    private function anchors(string $html): array
+    {
+        preg_match_all('/href="#([^"]+)"/', $html, $m);
+
+        return $m[1];
+    }
+
+    /**
+     * The ids that actually exist on headings in the rendered content.
+     *
+     * Takes the first id per heading, the way an HTML parser does: when an
+     * element carries the same attribute twice, the first one wins and the rest
+     * are dropped. Matching the last one would paper over exactly the defect
+     * test_no_heading_carries_two_ids is about.
+     */
+    private function ids(string $html): array
+    {
+        preg_match_all('/<h[1-6]\b[^>]*>/i', $html, $tags);
+
+        return collect($tags[0])
+            ->map(fn ($tag) => preg_match('/\bid="([^"]*)"/', $tag, $m) ? $m[1] : null)
+            ->filter()
+            ->values()
+            ->all();
+    }
+
+    /**
+     * Half the contract, and the half that always holds: no anchor may point at
+     * a heading that does not carry that id.
+     */
+    private function assertNoDanglingAnchors(string $html, string $because)
+    {
+        $anchors = $this->anchors($html);
+
+        $this->assertNotEmpty($anchors, 'The list rendered no anchors at all.');
+
+        $dangling = array_values(array_diff($anchors, $this->ids($html)));
+        $this->assertSame([], $dangling, $because."\nAnchors without a matching heading id: ".implode(', ', $dangling));
+    }
+
+    /**
+     * The other half, and only for documents the list covers completely. A
+     * heading outside `from`/`depth` still gets an id, and nothing links to it.
+     * That is what the caller asked for, not a defect.
+     */
+    private function assertAnchorsResolve(string $html, string $because)
+    {
+        $this->assertNoDanglingAnchors($html, $because);
+
+        $unreachable = array_values(array_diff($this->ids($html), $this->anchors($html)));
+        $this->assertSame([], $unreachable, $because."\nHeadings the list cannot reach: ".implode(', ', $unreachable));
+    }
+
+    /**
+     * A page as a customer builds it: the list, then the content itself run
+     * through the modifier.
+     */
+    private const PAGE = '{{ toc :content="body" :from="from" :depth="depth" }}<a href="#{{ toc_id }}">{{ toc_title }}</a>{{ if children }}{{ *recursive children* }}{{ /if }}{{ /toc }}{{ body | toc }}';
+
+    private function page(string $body, string $from = 'h1', int $depth = 3): string
+    {
+        return $this->render(self::PAGE, compact('body', 'from', 'depth'));
+    }
+
+    public function test_the_simple_case_holds()
+    {
+        // The baseline. If this ever fails, the test itself is wrong.
+        $html = $this->page('<h1>Einstieg</h1><h2>Atem</h2><h3>Stütze</h3>');
+
+        $this->assertAnchorsResolve($html, 'Unique titles within the default depth must line up.');
+    }
+
+    public function test_duplicate_titles_line_up()
+    {
+        // Two headings with the same text. Both sides have to number them the
+        // same way, or the second link goes to the first heading.
+        $html = $this->page('<h2>Atem</h2><h3>Übung</h3><h2>Resonanz</h2><h3>Übung</h3>');
+
+        $this->assertAnchorsResolve($html, 'Repeated headings must get the same suffix on both sides.');
+    }
+
+    public function test_a_duplicate_above_the_starting_level_does_not_shift_the_numbering()
+    {
+        // With from="h2" the tag never sees the h1, but the modifier injects
+        // into it and counts it. That used to make the two sides disagree about
+        // the second "Atem".
+        //
+        // The h1 keeps an id nobody links to, which is exactly what from="h2"
+        // asks for, so only the dangling direction is checked here.
+        $html = $this->page('<h1>Atem</h1><h2>Atem</h2><h2>Resonanz</h2>', 'h2');
+
+        $this->assertNoDanglingAnchors($html, 'A skipped heading above `from` must not shift the anchors below it.');
+        $this->assertSame(['atem-2', 'resonanz'], $this->anchors($html), 'The list must link the two h2 headings.');
+        $this->assertSame(['atem', 'atem-2', 'resonanz'], $this->ids($html), 'Every heading still gets an id.');
+    }
+
+    public function test_headings_below_the_third_level_get_ids()
+    {
+        // from="h2" with depth 3 lists h2 to h4. The modifier builds its regex
+        // from a Parser that still sits at the default maxLevel of 3.
+        $html = $this->page('<h2>Atem</h2><h3>Stütze</h3><h4>Zwerchfell</h4>', 'h2');
+
+        $this->assertAnchorsResolve($html, 'Every level the list shows must also be injected.');
+    }
+
+    public function test_a_manual_anchor_wins_on_both_sides()
+    {
+        // Bard's anchor button and save_html both produce headings that already
+        // carry an id. That id is the anchor, and the list has to use it.
+        $html = $this->page('<h2 id="atemstuetze">Atem und Stütze</h2><h2>Resonanz</h2>');
+
+        $this->assertAnchorsResolve($html, 'A hand-written id is the anchor; the list must not slugify past it.');
+    }
+
+    public function test_no_heading_carries_two_ids()
+    {
+        // The guard in Parser::injectIds requires whitespace or '>' behind the
+        // closing quote, which never follows the last attribute. So an existing
+        // id is not detected and a second one is appended. The result is invalid
+        // HTML, and the browser keeps the first id, not the one the list links to.
+        $html = $this->page('<h2 id="atemstuetze">Atem und Stütze</h2>');
+
+        preg_match_all('/<h[1-6]\b[^>]*>/i', $html, $tags);
+
+        foreach ($tags[0] as $tag) {
+            $this->assertLessThan(
+                2,
+                preg_match_all('/\bid="/', $tag),
+                'A heading must not end up with two id attributes: '.$tag
+            );
+        }
+    }
+
+    public function test_two_fields_on_one_page_stay_independent()
+    {
+        // The modifier goes through a facade, and the facade caches its Parser
+        // for the whole request. The second call inherits the first registry.
+        $html = $this->render(
+            '{{ toc :content="one" }}<a href="#{{ toc_id }}">{{ toc_title }}</a>{{ /toc }}{{ one | toc }}'
+            .'{{ toc :content="two" }}<a href="#{{ toc_id }}">{{ toc_title }}</a>{{ /toc }}{{ two | toc }}',
+            ['one' => '<h2>Atem</h2>', 'two' => '<h2>Atem</h2>']
+        );
+
+        // Same title in both fields, so both sides must produce the same two
+        // ids in the same order.
+        $this->assertSame(
+            $this->anchors($html),
+            $this->ids($html),
+            'Two modifier calls in one request must not renumber each other.'
+        );
+    }
+
+    public function test_special_characters_survive_both_paths()
+    {
+        $html = $this->page('<h2>Öffnung &amp; Weite</h2><h3>Größe</h3>');
+
+        $this->assertAnchorsResolve($html, 'Umlauts and entities must slugify identically on both sides.');
+    }
+
+    public function test_formatted_headings_line_up()
+    {
+        $html = $this->page('<h2>Die <strong>Stütze</strong> im Chor</h2><h3>Übung</h3>');
+
+        $this->assertAnchorsResolve($html, 'Inline markup must not change the slug on one side only.');
+    }
+}

--- a/tests/Unit/AnchorsTest.php
+++ b/tests/Unit/AnchorsTest.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace Tests\Unit;
+
+use Goldnead\StatamicToc\Anchors\IdInjector;
+use Goldnead\StatamicToc\Anchors\Slugger;
+use Goldnead\StatamicToc\Extractors\BardExtractor;
+use Goldnead\StatamicToc\Extractors\HtmlExtractor;
+use Goldnead\StatamicToc\Heading;
+use Goldnead\StatamicToc\Registry;
+use Goldnead\StatamicToc\Tests\TestCase;
+
+class AnchorsTest extends TestCase
+{
+    // ---------------------------------------------------------------- Slugger
+
+    public function test_slugs_are_unique_within_a_document()
+    {
+        $anchors = (new Slugger)->assign([
+            new Heading('Atem', 2),
+            new Heading('Atem', 2),
+            new Heading('Atem', 3),
+        ]);
+
+        $this->assertSame(['atem', 'atem-2', 'atem-3'], $anchors);
+    }
+
+    public function test_an_existing_id_wins_over_a_generated_slug()
+    {
+        $anchors = (new Slugger)->assign([
+            new Heading('Atem und Stütze', 2, 'atemstuetze'),
+            new Heading('Resonanz', 2),
+        ]);
+
+        $this->assertSame(['atemstuetze', 'resonanz'], $anchors);
+    }
+
+    public function test_a_generated_slug_never_collides_with_an_existing_id()
+    {
+        // The manual anchor sits behind the heading that would generate the
+        // same slug. Claiming ids up front is what keeps them apart.
+        $anchors = (new Slugger)->assign([
+            new Heading('Atem', 2),
+            new Heading('Etwas anderes', 2, 'atem'),
+        ]);
+
+        $this->assertSame(['atem-2', 'atem'], $anchors);
+    }
+
+    public function test_an_empty_heading_gets_no_anchor()
+    {
+        $anchors = (new Slugger)->assign([
+            new Heading('', 2),
+            new Heading('Atem', 2),
+        ]);
+
+        $this->assertSame([null, 'atem'], $anchors);
+    }
+
+    public function test_a_title_that_slugifies_to_nothing_still_gets_an_anchor()
+    {
+        $anchors = (new Slugger)->assign([
+            new Heading('***', 2),
+            new Heading('###', 2),
+        ]);
+
+        $this->assertSame(['section', 'section-2'], $anchors);
+    }
+
+    // ------------------------------------------------------------- IdInjector
+
+    public function test_injects_into_every_level()
+    {
+        $html = '<h1>A</h1><h4>B</h4><h6>C</h6>';
+        $anchors = ['a', 'b', 'c'];
+
+        $out = (new IdInjector)->inject($html, $anchors);
+
+        $this->assertSame('<h1 id="a">A</h1><h4 id="b">B</h4><h6 id="c">C</h6>', $out);
+    }
+
+    public function test_leaves_an_existing_id_alone_wherever_it_sits()
+    {
+        // The old guard required whitespace or '>' behind the closing quote, so
+        // an id as the last attribute went undetected and a second was added.
+        $cases = [
+            '<h2 id="a">X</h2>',
+            '<h2 id="a" class="b">X</h2>',
+            '<h2 class="b" id="a">X</h2>',
+            "<h2 id='a'>X</h2>",
+        ];
+
+        foreach ($cases as $html) {
+            $this->assertSame($html, (new IdInjector)->inject($html, ['x']), $html);
+        }
+    }
+
+    public function test_keeps_the_rest_of_the_markup_byte_for_byte()
+    {
+        $html = '<h2 class="mt-4" data-x="a>b">Titel</h2><p>Text mit <em>Betonung</em> &amp; Zeichen.</p><br>';
+
+        $out = (new IdInjector)->inject($html, ['titel']);
+
+        $this->assertStringContainsString('<p>Text mit <em>Betonung</em> &amp; Zeichen.</p><br>', $out);
+        $this->assertStringContainsString('id="titel"', $out);
+    }
+
+    public function test_adds_extra_attributes_with_the_id_placeholder()
+    {
+        $out = (new IdInjector)->inject('<h2>Titel</h2>', ['titel'], 'x-on:click="go(\'[id]\')"');
+
+        $this->assertSame('<h2 id="titel" x-on:click="go(\'titel\')">Titel</h2>', $out);
+    }
+
+    public function test_a_heading_without_an_anchor_is_left_alone()
+    {
+        $this->assertSame('<h2></h2>', (new IdInjector)->inject('<h2></h2>', [null]));
+    }
+
+    // ----------------------------------------------------------------- Shared
+
+    public function test_bard_and_its_rendered_html_get_the_same_anchors()
+    {
+        // The real page: the tag reads the Bard array, the modifier gets the
+        // rendered HTML of the same field. Two very different strings, one
+        // sequence of headings. Hashing the content instead of the headings
+        // would hand out two different sets of anchors here.
+        $bard = [
+            ['type' => 'heading', 'attrs' => ['level' => 2], 'content' => [['type' => 'text', 'text' => 'Atem']]],
+            ['type' => 'heading', 'attrs' => ['level' => 3], 'content' => [['type' => 'text', 'text' => 'Übung']]],
+            ['type' => 'heading', 'attrs' => ['level' => 2], 'content' => [['type' => 'text', 'text' => 'Atem']]],
+        ];
+
+        $html = '<h2>Atem</h2><p>Text.</p><h3>Übung</h3><h2>Atem</h2>';
+
+        $registry = new Registry;
+
+        $fromBard = $registry->anchorsFor((new BardExtractor)->extract($bard));
+        $fromHtml = $registry->anchorsFor((new HtmlExtractor)->extract($html));
+
+        $this->assertSame(['atem', 'ubung', 'atem-2'], $fromBard);
+        $this->assertSame($fromBard, $fromHtml);
+    }
+
+    public function test_the_registry_decides_once_per_document()
+    {
+        $registry = new Registry;
+        $headings = [new Heading('Atem', 2)];
+
+        $first = $registry->anchorsFor($headings);
+        $second = $registry->anchorsFor($headings);
+
+        // Asking twice must not walk the counter forward. This is the defect
+        // behind two modifier calls on one page renumbering each other.
+        $this->assertSame(['atem'], $first);
+        $this->assertSame($first, $second);
+    }
+
+    public function test_two_different_documents_do_not_share_a_counter()
+    {
+        $registry = new Registry;
+
+        $one = $registry->anchorsFor([new Heading('Atem', 2)]);
+        $two = $registry->anchorsFor([new Heading('Atem', 3)]);
+
+        $this->assertSame(['atem'], $one);
+        $this->assertSame(['atem'], $two);
+    }
+}


### PR DESCRIPTION
Dritter Schritt. **Macht den Vertragstest aus #37 grün.** Ziel-Branch ist `feature/v2-extraction` (PR #38), damit der Diff lesbar bleibt; beide gehen zusammen nach `v2`.

## Was jetzt gilt

Tag und Modifier rechnen keine IDs mehr aus. Sie lesen sie aus einer Registry.

- **`Slugger`** — die einzige Stelle, die entscheidet, wie eine Überschrift heißt. Vorhandene IDs werden **vor** dem ersten generierten Slug beansprucht, damit ein generierter nie mit einem handgesetzten Anker weiter unten im Dokument kollidiert.
- **`Registry`** — eine pro Request, memoisiert pro Dokument.
- **`IdInjector`** — schreibt die Anker ins HTML.

## Warum die Registry nicht über den Rohinhalt schlüsselt

Der reale Fall: der Tag liest das Bard-Array, der Modifier bekommt das gerenderte HTML desselben Felds. Zwei völlig verschiedene Strings, dieselbe Folge von Überschriften. Ein Hash über den Rohinhalt würde hier zwei verschiedene Anker-Sätze ausgeben. Geschlüsselt wird deshalb über Level, vorhandene ID und Titel der extrahierten Überschriften. Abgedeckt von `test_bard_and_its_rendered_html_get_the_same_anchors`.

## Vier Defekte fallen weg

| Fall | vorher |
|---|---|
| h4 und tiefer | bekamen gar keine ID, weil der Injector sein Regex aus einem Parser beim Default `maxLevel = 3` baute |
| `from="h2"` über einer Dublette | verschob die Anker darunter |
| Handgesetzte ID | wurde von der Liste ignoriert und überslugifiziert |
| Zwei Modifier-Aufrufe pro Request | nummerierten sich gegenseitig um |

Dazu der Befund, den der Vertragstest selbst zutage gefördert hat: eine vorhandene ID in letzter Attributposition blieb unentdeckt, es wurde eine zweite angehängt. Ungültiges HTML, und der Browser behält die erste, während die Liste die zweite verlinkt.

## Abweichung vom Entwurf

Der Injector ist eine gezielte Ersetzung der öffnenden Überschriften-Tags, **kein** DOMDocument-Round-Trip wie im Konzept skizziert. Das hier läuft über veröffentlichte Inhalte, und einen ganzen Artikel neu zu serialisieren würde stillschweigend Markup umschreiben, um das niemand gebeten hat. Angefasst werden nur `<h1>`..`<h6>`-Öffnungstags, alles andere bleibt Byte für Byte stehen. Abgedeckt von `test_keeps_the_rest_of_the_markup_byte_for_byte`.

## Eine Zusicherung im Vertragstest war zu streng

Sie verlangte, dass **jede** Überschrift, die der Modifier anfasst, aus der Liste erreichbar ist. Das kann nicht gelten, wenn `from`/`depth` die Liste bewusst einschränken: eine Überschrift außerhalb der Spanne behält ihre ID, und niemand verlinkt sie — genau wie bestellt.

Getrennt in zwei Zusicherungen: die dangling-Richtung (kein Anker ohne Ziel) gilt immer, die reachable-Richtung nur für Dokumente, die die Liste vollständig abdeckt.

**Gegenprobe, damit das nicht nach Weichspülen aussieht:** der korrigierte Test fällt auf dem Stand von PR #38 unverändert in allen fünf ursprünglichen Fällen. Er wurde nicht abgeschwächt, nur präzisiert.

```
Tests: 92, Assertions: 207
```

Schließt #37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)