### PR TITLE
[v2] Schritt 4: Options, to-Parameter, konsistenter Zähler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,16 @@ All notable changes to `statamic-toc` will be documented in this file.
   invalid HTML and left the anchor pointing nowhere.
 - Excluding a heading from the list no longer changes the anchors of the
   others.
+- New `to` parameter on the tag, an absolute level: `{{ toc from="h2" to="h4" }}`.
+  `depth` keeps working and says the same thing relative to `from`; when both
+  are given, `to` wins.
+- **Breaking:** `{{ toc:count }}` counts what the list shows. It used to force
+  the depth to 6 and report a different number than the list right underneath
+  it. Templates that relied on the old number to ask "are there any headings at
+  all" want `{{ toc:count depth="6" }}`.
+- Options live in one immutable `Options` object instead of two mutable level
+  fields recomputed from each other. `Parser::flattenFrom()`, an empty stub
+  marked TODO since 2021, is gone.
 
 ## 2026-07-30 v1.9
 

--- a/README.md
+++ b/README.md
@@ -219,6 +219,17 @@ instead of publishing it, add the addon path to the content sources in your Tail
 The partial only renders the list. The anchors point at the IDs the modifier injects, so the content
 field itself still needs `{{ your_field | toc }}`.
 
+### Heading levels
+
+`from` is the level the list starts at, `to` the level it stops at, both absolute:
+
+```
+{{ toc from="h2" to="h4" }}
+```
+
+`depth` says the same thing relative to `from`, and is what most templates use. `from="h2"` with
+`depth="3"` covers h2 to h4. When both `to` and `depth` are given, `to` wins.
+
 ### Excluding headings
 
 Pass `exclude` to leave individual headings out of the list. A comma-separated string matches
@@ -248,8 +259,8 @@ When it evaluates to `false`, the tag returns an empty list and `no_results` is 
 
 ### The `toc:count` Tag
 
-Returns the number of headings found. Pass it the same `field`, `depth` and `from` parameters as
-the list itself, otherwise it counts a different set:
+Returns the number of headings the list would show. Give it the same parameters as the list, and
+it reports the same number:
 
 ```
 {{ if {toc:count field="article" depth="3"} > 0 }}
@@ -289,7 +300,8 @@ You can control the behaviour with the following tag-parameters:
 | `is_flat` | When true the list will be displayed as a flat array without nested `children` | _(boolean)_ `false`          |
 | `field`   | The name of the bard-field.                                                    | _(string)_ `"article"`       |
 | `content` | Content of the bard-structure or HTML String                                   | _(string/array/null)_ `null` |
-| `from`    | The starting point from where the list should be outputted                     | _(string)_ `h1`              |
+| `from`    | The level the list starts at                                                    | _(string)_ `h1`              |
+| `to`      | The level the list stops at, absolute. Wins over `depth`                       | _(string/null)_ `null`       |
 | `exclude` | Comma-separated headings or a regex pattern to omit from the list              | _(string/null)_ `null`       |
 | `when`    | Returns an empty list when this evaluates to false                             | _(bool)_ `true`              |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -246,6 +246,17 @@ instead of publishing it, add the addon path to the content sources in your Tail
 The partial only renders the list. The anchors point at the IDs the modifier injects, so the content
 field itself still needs `{{ your_field | toc }}`.
 
+### Heading levels
+
+`from` is the level the list starts at, `to` the level it stops at, both absolute:
+
+```
+{{ toc from="h2" to="h4" }}
+```
+
+`depth` says the same thing relative to `from`, and is what most templates use. `from="h2"` with
+`depth="3"` covers h2 to h4. When both `to` and `depth` are given, `to` wins.
+
 ### Excluding headings
 
 Pass `exclude` to leave individual headings out of the list. A comma-separated string matches
@@ -305,7 +316,8 @@ You can control the behaviour with the following tag-parameters:
 | `is_flat` | When true the list will be displayed as a flat array without nested `children` | _(boolean)_ `false`          |
 | `field`   | The name of the bard-field.                                                    | _(string)_ `"article"`       |
 | `content` | Content of the bard-structure or HTML String                                   | _(string/array/null)_ `null` |
-| `from`    | The starting point from where the list should be outputted                     | _(string)_ `h1`              |
+| `from`    | The level the list starts at                                                    | _(string)_ `h1`              |
+| `to`      | The level the list stops at, absolute. Wins over `depth`                       | _(string/null)_ `null`       |
 | `exclude` | Comma-separated headings or a regex pattern to omit from the list              | _(string/null)_ `null`       |
 | `when`    | Returns an empty list when this evaluates to false                             | _(bool)_ `true`              |
 

--- a/src/Options.php
+++ b/src/Options.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Goldnead\StatamicToc;
+
+/**
+ * What the list shows. Immutable: every change hands back a new instance, so a
+ * parser cannot drift into a half-applied state.
+ *
+ * `from` and `to` are absolute heading levels. Depth is the relative way of
+ * saying the same thing and is kept because that is what existing templates
+ * use, but it is derived from the range rather than stored next to it.
+ * Recomputing both from each other in both directions is what made `from()`
+ * after `depth()` silently widen the range.
+ */
+final class Options
+{
+    private function __construct(
+        public readonly int $from,
+        public readonly int $to,
+        public readonly bool $flat,
+        public readonly ?string $exclude,
+    ) {}
+
+    public static function default(): self
+    {
+        return new self(from: 1, to: 3, flat: false, exclude: null);
+    }
+
+    /**
+     * A level given as either 2 or "h2", clamped to what HTML has.
+     */
+    public static function level(string|int|null $level, int $fallback): int
+    {
+        if ($level === null || $level === '') {
+            return $fallback;
+        }
+
+        $number = is_string($level) ? (int) ltrim(trim($level), 'hH') : (int) $level;
+
+        return $number < 1 ? $fallback : min(6, $number);
+    }
+
+    /**
+     * How many levels the list spans, counted from `from`.
+     */
+    public function depth(): int
+    {
+        return $this->to - $this->from + 1;
+    }
+
+    public function withFrom(string|int $level): self
+    {
+        $from = self::level($level, $this->from);
+
+        // The range keeps its width when the starting point moves.
+        return new self($from, min(6, $from + $this->depth() - 1), $this->flat, $this->exclude);
+    }
+
+    public function withTo(string|int $level): self
+    {
+        return new self($this->from, max($this->from, self::level($level, $this->to)), $this->flat, $this->exclude);
+    }
+
+    public function withDepth(int $depth): self
+    {
+        return new self($this->from, min(6, $this->from + max(1, $depth) - 1), $this->flat, $this->exclude);
+    }
+
+    public function withFlat(bool $flat = true): self
+    {
+        return new self($this->from, $this->to, $flat, $this->exclude);
+    }
+
+    public function withExclude(?string $exclude): self
+    {
+        return new self($this->from, $this->to, $this->flat, $exclude === '' ? null : $exclude);
+    }
+
+    public function covers(int $level): bool
+    {
+        return $level >= $this->from && $level <= $this->to;
+    }
+}

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -14,15 +14,9 @@ class Parser
 {
     private $content;
 
-    private $maxLevel = 3;
-
-    private $minLevel = 1;
-
     private $headings = [];
-    
-    private $exclude;
 
-    private $isFlat = false;
+    private Options $options;
 
     /**
      * Constructor.
@@ -31,9 +25,22 @@ class Parser
      */
     public function __construct($content = null)
     {
+        $this->options = Options::default();
+
         if ($content) {
             $this->setContent($content);
         }
+
+        return $this;
+    }
+
+    /**
+     * Replaces the whole option set at once. The fluent setters below stay for
+     * anyone driving the parser directly.
+     */
+    public function options(Options $options): self
+    {
+        $this->options = $options;
 
         return $this;
     }
@@ -88,14 +95,28 @@ class Parser
     }
 
     /**
-     * Sets the given List-Depth
+     * How many levels the list spans, counted from the starting level.
      *
      * @param  int  $depth
      * @return $this
      */
     public function depth($depth)
     {
-        $this->maxLevel = $depth + $this->minLevel - 1;
+        $this->options = $this->options->withDepth((int) $depth);
+
+        return $this;
+    }
+
+    /**
+     * The deepest level the list shows, as an absolute level. Says the same
+     * thing as depth() without the arithmetic.
+     *
+     * @param  string|int  $level
+     * @return $this
+     */
+    public function to($level)
+    {
+        $this->options = $this->options->withTo($level);
 
         return $this;
     }
@@ -108,22 +129,7 @@ class Parser
      */
     public function from($start)
     {
-        // parse string if it has the syntax "h(int)" (eg. h2)
-        if (is_string($start)) {
-            $start = intval(ltrim($start, 'h'));
-        }
-        // reset starting value if it is below or above the supported ones
-        if ($start < 1) {
-            $start = 1;
-        } elseif ($start > 6) {
-            $start = 6;
-        }
-
-        $currentDepth = $this->maxLevel - $this->minLevel + 1;
-        $this->minLevel = $start;
-        // our depth is relative to the minLevel. So we need to update it if
-        // the minLevel changes
-        $this->depth($currentDepth);
+        $this->options = $this->options->withFrom($start);
 
         return $this;
     }
@@ -136,7 +142,7 @@ class Parser
      */
     public function exclude($exclude)
     {
-        $this->exclude = $exclude;
+        $this->options = $this->options->withExclude($exclude);
 
         return $this;
     }
@@ -148,19 +154,10 @@ class Parser
      */
     public function flatten()
     {
-        $this->isFlat = true;
+        $this->options = $this->options->withFlat();
 
         return $this;
     }
-
-    /**
-     * Stops the recursion at the given level.
-     * TODO/FEATURE/WHY?
-     *
-     * @param [type] $level
-     * @return void
-     */
-    public function flattenFrom($level) {}
 
     /**
      * Sets the flattening only if the given parameter is true.
@@ -226,7 +223,7 @@ class Parser
     private function assemble(array $extracted, array $anchors): array
     {
         foreach ($extracted as $index => $heading) {
-            if ($heading->level < $this->minLevel || $heading->level > $this->maxLevel) {
+            if (! $this->options->covers($heading->level)) {
                 continue;
             }
 
@@ -302,7 +299,7 @@ class Parser
         }
 
         // return flat array if flag is true, nest it if not
-        return $this->isFlat ? $this->headings : $this->nestHeadings();
+        return $this->options->flat ? $this->headings : $this->nestHeadings();
     }
 
     /**
@@ -310,22 +307,22 @@ class Parser
      */
     private function shouldIncludeHeading(string $title): bool
     {
-        if (! $this->exclude) {
+        if (! $this->options->exclude) {
             return true;
         }
 
         // Treat as regex only when it looks like a delimited pattern (e.g. /foo/i).
         // This avoids calling preg_match on plain strings, which would emit warnings.
-        if (preg_match('/^([^\w\s\\\\])[^\1]*\1[gimsuy]*$/', $this->exclude)) {
+        if (preg_match('/^([^\w\s\\\\])[^\1]*\1[gimsuy]*$/', $this->options->exclude)) {
             try {
-                return ! preg_match($this->exclude, $title);
+                return ! preg_match($this->options->exclude, $title);
             } catch (\Throwable $e) {
                 // Invalid regex — fall through to string match
             }
         }
 
         // Comma-separated string match; skip empty tokens to avoid matching everything
-        foreach (explode(',', $this->exclude) as $exc) {
+        foreach (explode(',', $this->options->exclude) as $exc) {
             $exc = trim($exc);
             if ($exc !== '' && stripos($title, $exc) !== false) {
                 return false;

--- a/src/Tags/Toc.php
+++ b/src/Tags/Toc.php
@@ -1,17 +1,16 @@
 <?php
 
 /**
- * This is the Tag that generates the TOC-Element.
- * This only works for articles where the contents are stored in a
- * value named "article".
- *
+ * The {{ toc }} tag.
  */
 
 namespace Goldnead\StatamicToc\Tags;
 
-use Statamic\Tags\Tags;
+use Goldnead\StatamicToc\Options;
 use Goldnead\StatamicToc\Parser;
+use Statamic\Fields\Value;
 use Statamic\Tags\Concerns;
+use Statamic\Tags\Tags;
 
 class Toc extends Tags
 {
@@ -26,76 +25,97 @@ class Toc extends Tags
      */
     public function index()
     {
-        $when = $this->params->get('when', true);
-        if ($when instanceof \Statamic\Fields\Value) {
-            $when = $when->raw();
-        }
-        if ($when === false || $when === 'false' || $when === 0 || $when === '0') {
-            return [];
-        }
-        
-        // get the supported header-levels
-
-        // get the supported header-levels
-        $depth = $this->params->int("depth", 3);
-        $start = $this->params->get('from', "h1");
-        // get raw data of the document
-        $field = $this->params->get("field", "article");
-
-        $content = $this->params->get("content");
-
-        // Statamic 5+ runtime Antlers passes dynamic params as Value objects.
-        // Unwrap so the Parser receives a raw string or Bard array.
-        if ($content instanceof \Statamic\Fields\Value) {
-            $content = $content->raw();
-        }
-
-        if (!$content && !$this->context->get($field)) {
-            // return an empty array so the $this->count() function works properly
+        if (! $this->enabled()) {
+            // An empty array rather than null, so count() and no_results keep
+            // working the way templates expect.
             return [];
         }
 
-        $raw = $content;
+        $content = $this->content();
 
-        if (!$content) {
-            $field = $this->context->get($field);
-            $raw = is_string($field) ? $field : $field->raw();
+        if ($content === null) {
+            return [];
         }
-
-        $isFlat = $this->params->bool("is_flat");
-        $exclude = $this->params->get("exclude");
-        if ($exclude instanceof \Statamic\Fields\Value) {
-            $exclude = $exclude->raw();
-        }
-        $exclude = $exclude ? (string) $exclude : null;
-
-        // create parser and generate TOC items
-        $toc = new Parser($raw);
-        $toc->depth($depth)
-            ->from($start)
-            ->exclude($exclude)
-            ->flattenIf($isFlat);
 
         return $this->output(
-            $toc->build()
+            (new Parser($content))->options($this->options())->build()
         );
     }
 
     /**
      * The {{ toc:count }} tag.
      *
-     * @return integer
+     * Counts what the list would show. It used to force the depth to 6 and so
+     * reported a different number than the list right underneath it.
+     *
+     * @return int
      */
     public function count()
     {
-        $this->params->put("depth", $this->params->int("depth", 6));
-
         $result = $this->index();
 
         if (empty($result)) {
             return 0;
         }
 
-        return isset($result[0]) ? $result[0]["total_results"] : $result["total_results"];
+        return isset($result[0]) ? $result[0]['total_results'] : $result['total_results'];
+    }
+
+    private function options(): Options
+    {
+        $options = Options::default()
+            ->withDepth($this->params->int('depth', 3))
+            ->withFrom($this->param('from') ?? 'h1')
+            ->withFlat($this->params->bool('is_flat'))
+            ->withExclude($this->stringParam('exclude'));
+
+        // `to` is absolute and wins over the relative depth when both are given.
+        return $this->params->has('to')
+            ? $options->withTo($this->param('to'))
+            : $options;
+    }
+
+    /**
+     * The content to parse: either handed in directly or read from a field in
+     * the current context.
+     */
+    private function content(): mixed
+    {
+        if ($content = $this->param('content')) {
+            return $content;
+        }
+
+        $field = $this->context->get($this->params->get('field', 'article'));
+
+        if (! $field) {
+            return null;
+        }
+
+        return $field instanceof Value ? $field->raw() : $field;
+    }
+
+    private function enabled(): bool
+    {
+        $when = $this->param('when') ?? true;
+
+        return ! in_array($when, [false, 'false', 0, '0'], true);
+    }
+
+    /**
+     * Statamic 5 and up hand dynamic parameters over as Value objects. The
+     * parser wants the raw string or Bard array underneath.
+     */
+    private function param(string $name): mixed
+    {
+        $value = $this->params->get($name);
+
+        return $value instanceof Value ? $value->raw() : $value;
+    }
+
+    private function stringParam(string $name): ?string
+    {
+        $value = $this->param($name);
+
+        return $value === null || $value === '' ? null : (string) $value;
     }
 }

--- a/tests/Unit/OptionsTest.php
+++ b/tests/Unit/OptionsTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Tests\Unit;
+
+use Goldnead\StatamicToc\Options;
+use Goldnead\StatamicToc\Parser;
+use Goldnead\StatamicToc\Tests\TestCase;
+
+class OptionsTest extends TestCase
+{
+    private function levels(array $tree): array
+    {
+        $levels = [];
+
+        foreach ($tree as $key => $item) {
+            if (! is_int($key)) {
+                continue;
+            }
+
+            $levels[] = $item['level'];
+            $levels = array_merge($levels, $this->levels($item['children'] ?? []));
+        }
+
+        return $levels;
+    }
+
+    private function document(): string
+    {
+        return '<h1>1</h1><h2>2</h2><h3>3</h3><h4>4</h4><h5>5</h5><h6>6</h6>';
+    }
+
+    // ---------------------------------------------------------------- Options
+
+    public function test_a_level_is_read_as_a_number_or_as_h_notation()
+    {
+        $this->assertSame(2, Options::level('h2', 1));
+        $this->assertSame(2, Options::level('H2', 1));
+        $this->assertSame(2, Options::level(2, 1));
+        $this->assertSame(6, Options::level('h9', 1), 'Clamped to what HTML has.');
+        $this->assertSame(1, Options::level('h0', 1), 'Nonsense falls back.');
+        $this->assertSame(3, Options::level(null, 3));
+        $this->assertSame(3, Options::level('', 3));
+    }
+
+    public function test_the_range_keeps_its_width_when_the_start_moves()
+    {
+        $options = Options::default()->withDepth(2)->withFrom('h3');
+
+        $this->assertSame(3, $options->from);
+        $this->assertSame(4, $options->to);
+        $this->assertSame(2, $options->depth());
+    }
+
+    public function test_setting_the_start_twice_does_not_widen_the_range()
+    {
+        $once = Options::default()->withDepth(2)->withFrom('h2');
+        $twice = Options::default()->withDepth(2)->withFrom('h2')->withFrom('h2');
+
+        $this->assertSame($once->to, $twice->to);
+    }
+
+    public function test_to_is_absolute()
+    {
+        $options = Options::default()->withFrom('h2')->withTo('h5');
+
+        $this->assertSame(2, $options->from);
+        $this->assertSame(5, $options->to);
+        $this->assertSame(4, $options->depth());
+    }
+
+    public function test_to_never_falls_below_from()
+    {
+        $options = Options::default()->withFrom('h4')->withTo('h2');
+
+        $this->assertSame(4, $options->to);
+    }
+
+    public function test_options_are_immutable()
+    {
+        $base = Options::default();
+        $changed = $base->withDepth(6);
+
+        $this->assertSame(3, $base->to);
+        $this->assertSame(6, $changed->to);
+    }
+
+    // ----------------------------------------------------------------- Parser
+
+    public function test_the_parser_takes_a_whole_option_set()
+    {
+        $tree = (new Parser($this->document()))
+            ->options(Options::default()->withFrom('h2')->withTo('h4'))
+            ->flatten()
+            ->build();
+
+        $this->assertSame([2, 3, 4], $this->levels($tree));
+    }
+
+    public function test_to_and_depth_describe_the_same_range()
+    {
+        $withDepth = (new Parser($this->document()))->from('h2')->depth(3)->flatten()->build();
+        $withTo = (new Parser($this->document()))->from('h2')->to('h4')->flatten()->build();
+
+        $this->assertSame($this->levels($withDepth), $this->levels($withTo));
+        $this->assertSame([2, 3, 4], $this->levels($withTo));
+    }
+
+    public function test_the_order_of_from_and_depth_no_longer_matters()
+    {
+        $a = (new Parser($this->document()))->from('h2')->depth(2)->flatten()->build();
+        $b = (new Parser($this->document()))->depth(2)->from('h2')->flatten()->build();
+
+        $this->assertSame([2, 3], $this->levels($a));
+        $this->assertSame($this->levels($a), $this->levels($b));
+    }
+}

--- a/tests/Unit/TagOptionsTest.php
+++ b/tests/Unit/TagOptionsTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Tests\Unit;
+
+use Goldnead\StatamicToc\ServiceProvider;
+use Statamic\Facades\Antlers;
+use Statamic\Testing\AddonTestCase;
+
+class TagOptionsTest extends AddonTestCase
+{
+    protected string $addonServiceProvider = ServiceProvider::class;
+
+    private const DOCUMENT = '<h1>Eins</h1><h2>Zwei</h2><h3>Drei</h3><h4>Vier</h4><h5>Fünf</h5><h6>Sechs</h6>';
+
+    private function render(string $template, array $context = []): string
+    {
+        return trim((string) Antlers::parse($template, $context + ['body' => self::DOCUMENT], true));
+    }
+
+    private function titles(string $params = ''): array
+    {
+        $out = $this->render('{{ toc :content="body" '.$params.' }}[{{ toc_title }}]{{ if children }}{{ *recursive children* }}{{ /if }}{{ /toc }}');
+
+        preg_match_all('/\[([^\]]+)\]/', $out, $m);
+
+        return $m[1];
+    }
+
+    public function test_count_matches_the_list()
+    {
+        // It used to force the depth to 6 and report six while the list showed
+        // three, which is the inconsistency the README had to apologise for.
+        $this->assertSame(['Eins', 'Zwei', 'Drei'], $this->titles());
+        $this->assertSame('3', $this->render('{{ toc:count :content="body" }}'));
+    }
+
+    public function test_count_follows_the_same_parameters_as_the_list()
+    {
+        $this->assertSame(['Zwei', 'Drei', 'Vier'], $this->titles('from="h2"'));
+        $this->assertSame('3', $this->render('{{ toc:count :content="body" from="h2" }}'));
+
+        $this->assertSame(['Eins', 'Zwei', 'Drei', 'Vier', 'Fünf', 'Sechs'], $this->titles('depth="6"'));
+        $this->assertSame('6', $this->render('{{ toc:count :content="body" depth="6" }}'));
+    }
+
+    public function test_count_respects_exclude()
+    {
+        $this->assertSame(['Eins', 'Drei'], $this->titles('exclude="Zwei"'));
+        $this->assertSame('2', $this->render('{{ toc:count :content="body" exclude="Zwei" }}'));
+    }
+
+    public function test_the_to_parameter_sets_an_absolute_level()
+    {
+        $this->assertSame(['Eins', 'Zwei', 'Drei', 'Vier', 'Fünf'], $this->titles('to="h5"'));
+    }
+
+    public function test_to_wins_over_depth()
+    {
+        $this->assertSame(['Zwei', 'Drei'], $this->titles('from="h2" depth="6" to="h3"'));
+    }
+
+    public function test_from_and_depth_still_work_together()
+    {
+        $this->assertSame(['Zwei', 'Drei', 'Vier'], $this->titles('from="h2" depth="3"'));
+    }
+
+    public function test_when_false_still_yields_an_empty_list_and_a_zero_count()
+    {
+        $this->assertSame([], $this->titles('when="false"'));
+        $this->assertSame('0', $this->render('{{ toc:count :content="body" when="false" }}'));
+    }
+
+    public function test_a_missing_field_yields_a_zero_count()
+    {
+        $this->assertSame('0', $this->render('{{ toc:count field="gibt_es_nicht" }}'));
+    }
+}


### PR DESCRIPTION
Vierter Schritt. Ziel-Branch `feature/v2-anchors` (PR #40).

## `Options`

Ein unveränderliches Value Object ersetzt die zwei veränderlichen Level-Felder, die der Parser auseinander zurückgerechnet hat. Genau diese Arithmetik hat `from()` nach `depth()` die Spanne aufweiten lassen, und sie ist der Grund, warum die Reihenfolge der fluenten Aufrufe eine Rolle spielte.

Die fluenten Setter am Parser bleiben unverändert bestehen — sie sind öffentliche API und die Testsuite fährt sie direkt. Sie reichen ihre Argumente jetzt an `Options` weiter, statt selbst zu rechnen.

## Neu: `to`

```
{{ toc from="h2" to="h4" }}
```

Absolut statt relativ. `depth` funktioniert weiter und sagt dasselbe relativ zu `from`. Sind beide gesetzt, gewinnt `to`.

## Breaking: `{{ toc:count }}` zählt, was die Liste zeigt

Bisher schrieb `count()` `depth = 6` in die Parameter und meldete sechs Überschriften unter einer Liste, die drei zeigt. Das war kein Detail, sondern der dokumentierte Grund, warum man dem Zähler nicht trauen konnte.

Wer die alte Zahl gebraucht hat, um „gibt es überhaupt Überschriften" zu fragen, schreibt jetzt `{{ toc:count depth="6" }}`. Steht im CHANGELOG, `UPGRADE.md` kommt in Schritt 5.

## Weg

`Parser::flattenFrom()` — ein leerer Stub, seit 2021 mit `TODO/FEATURE/WHY?` im Docblock.

## Tests

`OptionsTest`: Level-Notation (`h2`, `2`, Klammerung), Spanne behält ihre Breite beim Verschieben des Starts, `to` ist absolut und fällt nie unter `from`, Unveränderlichkeit.

`TagOptionsTest`: läuft über gerendertes Antlers und prüft, dass der Zähler unter `from`, `depth` und `exclude` mit der Liste übereinstimmt, dazu `to` und dessen Vorrang.

**Gegenprobe:** fünf der acht Fälle in `TagOptionsTest` fallen auf dem Stand von PR #40.

```
Tests: 109, Assertions: 243
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)