### PR TITLE
test(anchors): den Anker-Vertrag um die Randfaelle erweitern

### DIFF
--- a/tests/Unit/AnchorContractTest.php
+++ b/tests/Unit/AnchorContractTest.php
@@ -5,6 +5,8 @@ namespace Goldnead\StatamicToc\Tests\Unit;
 use Goldnead\StatamicToc\Parser;
 use Goldnead\StatamicToc\ServiceProvider;
 use Goldnead\StatamicToc\Tests\Concerns\RendersAntlers;
+use League\CommonMark\CommonMarkConverter;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Statamic\Testing\AddonTestCase;
 
 /**
@@ -30,10 +32,14 @@ class AnchorContractTest extends AddonTestCase
 
     /**
      * The anchors the list links to, in order.
+     *
+     * Matches an empty fragment too. With `[^"]+` a bare href="#" simply fell
+     * out of the result, so a list entry that links nowhere looked like no list
+     * entry at all and every assertion below passed for the wrong reason.
      */
     private function anchors(string $html): array
     {
-        preg_match_all('/href="#([^"]+)"/', $html, $m);
+        preg_match_all('/href="#([^"]*)"/', $html, $m);
 
         return $m[1];
     }
@@ -45,14 +51,20 @@ class AnchorContractTest extends AddonTestCase
      * element carries the same attribute twice, the first one wins and the rest
      * are dropped. Matching the last one would paper over exactly the defect
      * test_no_heading_carries_two_ids is about.
+     *
+     * Reads single quotes and uppercase as well, because that is how ids reach
+     * the addon from hand-written HTML. A stricter pattern would report "no id
+     * here" for a heading that plainly has one.
      */
+    private const ID_ATTRIBUTE = '/\bid\s*=\s*(["\'])(.*?)\1/i';
+
     private function ids(string $html): array
     {
         preg_match_all('/<h[1-6]\b[^>]*>/i', $html, $tags);
 
         return collect($tags[0])
-            ->map(fn ($tag) => preg_match('/\bid="([^"]*)"/', $tag, $m) ? $m[1] : null)
-            ->filter()
+            ->map(fn ($tag) => preg_match(self::ID_ATTRIBUTE, $tag, $m) ? $m[2] : null)
+            ->filter(fn ($id) => $id !== null && $id !== '')
             ->values()
             ->all();
     }
@@ -158,7 +170,7 @@ class AnchorContractTest extends AddonTestCase
         foreach ($tags[0] as $tag) {
             $this->assertLessThan(
                 2,
-                preg_match_all('/\bid="/', $tag),
+                preg_match_all('/\bid\s*=\s*["\']/i', $tag),
                 'A heading must not end up with two id attributes: '.$tag
             );
         }
@@ -195,6 +207,90 @@ class AnchorContractTest extends AddonTestCase
         $html = $this->page('<h2>Die <strong>Stütze</strong> im Chor</h2><h3>Übung</h3>');
 
         $this->assertAnchorsResolve($html, 'Inline markup must not change the slug on one side only.');
+    }
+
+    public function test_an_empty_heading_is_left_out_on_both_sides()
+    {
+        // An editor leaves a heading block behind without typing into it. There
+        // is nothing to slugify, so the only consistent answer is: no list entry
+        // and no id. Half of that would be a link to "#" or an id nobody reaches.
+        $html = $this->page('<h2>Atem</h2><h2></h2><h2>Resonanz</h2>');
+
+        $this->assertAnchorsResolve($html, 'An empty heading must disappear from both sides, not from one.');
+        $this->assertSame(['atem', 'resonanz'], $this->anchors($html));
+        $this->assertStringNotContainsString('href="#"', $html, 'The list must not link to an empty fragment.');
+    }
+
+    public static function emptyHeadings(): array
+    {
+        return [
+            'whitespace' => ['<h2>   </h2>'],
+            'a line break' => ['<h2><br></h2>'],
+            'empty markup' => ['<h2><strong></strong></h2>'],
+        ];
+    }
+
+    #[DataProvider('emptyHeadings')]
+    public function test_a_heading_with_no_text_counts_as_empty(string $blank)
+    {
+        // Whitespace and empty inline markup carry no title either. Whether a
+        // heading is "empty" has to be decided on its text, not on its markup,
+        // or the tag and the modifier disagree about how many headings exist and
+        // every anchor after this one shifts by one.
+        $html = $this->page('<h2>Atem</h2>'.$blank.'<h2>Resonanz</h2>');
+
+        $this->assertAnchorsResolve($html, 'A heading without text must not shift the anchors below it.');
+        $this->assertSame(['atem', 'resonanz'], $this->anchors($html));
+    }
+
+    public function test_a_title_without_sluggable_characters_still_gets_an_anchor()
+    {
+        // Str::slug() returns an empty string for a title made of punctuation.
+        // Writing id="" would be an anchor nobody can reach, so both sides fall
+        // back to the same placeholder and keep counting from there.
+        $html = $this->page('<h2>???</h2><h2>!!!</h2>');
+
+        $this->assertAnchorsResolve($html, 'A punctuation-only title must still resolve.');
+        $this->assertSame(['section', 'section-2'], $this->anchors($html));
+    }
+
+    public function test_a_generated_slug_never_takes_an_id_the_document_already_uses()
+    {
+        // The hand-written id sits *below* the heading whose slug would collide
+        // with it. Claiming existing ids only as they are walked past would hand
+        // "atem" out twice and send the first link to the wrong heading.
+        $html = $this->page('<h2>Atem</h2><h2 id="atem">Andere</h2>');
+
+        $this->assertAnchorsResolve($html, 'A manual id further down still blocks the slug above it.');
+        $this->assertSame(['atem-2', 'atem'], $this->anchors($html));
+    }
+
+    public function test_an_existing_id_is_recognised_in_any_notation()
+    {
+        // Single quotes and uppercase are valid HTML and turn up in hand-written
+        // content. An id the addon fails to see is an id it overwrites or
+        // duplicates, and the list then links past it.
+        $html = $this->page("<h2 id='atemstuetze'>Atem und Stütze</h2><H2 ID=\"resonanz\">Resonanz</H2><h2>Weite</h2>");
+
+        $this->assertAnchorsResolve($html, 'An id must be honoured however it is quoted or cased.');
+        $this->assertSame(['atemstuetze', 'resonanz', 'weite'], $this->anchors($html));
+    }
+
+    public function test_the_list_of_a_markdown_field_matches_its_rendered_html()
+    {
+        // The normal shape of a markdown page: the tag is handed the source, the
+        // modifier the HTML that CommonMark made of it. Two different strings,
+        // one sequence of headings, and the anchors have to agree across them.
+        $markdown = "## Die **Stütze** im Chor\n\n### Übung\n\n## Übung\n";
+        $rendered = (string) (new CommonMarkConverter)->convert($markdown);
+
+        $html = $this->render(
+            '{{ toc :content="source" }}<a href="#{{ toc_id }}">{{ toc_title }}</a>{{ if children }}{{ *recursive children* }}{{ /if }}{{ /toc }}{{ rendered | toc }}',
+            ['source' => $markdown, 'rendered' => $rendered]
+        );
+
+        $this->assertAnchorsResolve($html, 'Markdown source and rendered HTML must anchor identically.');
+        $this->assertSame(['die-stutze-im-chor', 'ubung', 'ubung-2'], $this->anchors($html));
     }
 
     public function test_excluding_a_heading_does_not_shift_the_anchors_of_the_others()

--- a/tests/Unit/AnchorContractTest.php
+++ b/tests/Unit/AnchorContractTest.php
@@ -16,13 +16,14 @@ use Statamic\Testing\AddonTestCase;
  *   modifier actually injected, and every heading the modifier touches is
  *   reachable.
  *
- * Nothing enforced it so far. Tag and modifier each run their own Parser with
- * their own slug registry and agree only by coincidence, kept apart by the
+ * In v1 nothing enforced it. Tag and modifier each ran their own Parser with
+ * their own slug registry and agreed only by coincidence, kept apart by the
  * '-list' and '-text' suffixes in Parser::generateId(). Where the coincidence
- * breaks, the table of contents links into the void.
+ * broke, the table of contents linked into the void.
  *
- * These tests describe the target state. They are expected to fail until the
- * v2 rework puts both sides on one shared registry.
+ * Since v2 both sides read one shared Registry, so these tests pass. They are
+ * kept as the guard on that arrangement: each one names a case where the two
+ * sides used to drift apart, and stays here so they cannot drift again.
  */
 class AnchorContractTest extends AddonTestCase
 {
@@ -94,6 +95,25 @@ class AnchorContractTest extends AddonTestCase
 
         $unreachable = array_values(array_diff($this->ids($html), $this->anchors($html)));
         $this->assertSame([], $unreachable, $because."\nHeadings the list cannot reach: ".implode(', ', $unreachable));
+
+        // Cheap to check and easy to lose: a heading can satisfy both halves
+        // above and still be invalid HTML, because a second id was appended next
+        // to the one that already matched. Browsers keep the first, so nothing
+        // looks broken until the ids drift apart.
+        $this->assertNoHeadingCarriesTwoIds($html);
+    }
+
+    private function assertNoHeadingCarriesTwoIds(string $html)
+    {
+        preg_match_all('/<h[1-6]\b[^>]*>/i', $html, $tags);
+
+        foreach ($tags[0] as $tag) {
+            $this->assertLessThan(
+                2,
+                preg_match_all('/\bid\s*=\s*["\']/i', $tag),
+                'A heading must not end up with two id attributes: '.$tag
+            );
+        }
     }
 
     /**
@@ -165,15 +185,7 @@ class AnchorContractTest extends AddonTestCase
         // HTML, and the browser keeps the first id, not the one the list links to.
         $html = $this->page('<h2 id="atemstuetze">Atem und Stütze</h2>');
 
-        preg_match_all('/<h[1-6]\b[^>]*>/i', $html, $tags);
-
-        foreach ($tags[0] as $tag) {
-            $this->assertLessThan(
-                2,
-                preg_match_all('/\bid\s*=\s*["\']/i', $tag),
-                'A heading must not end up with two id attributes: '.$tag
-            );
-        }
+        $this->assertNoHeadingCarriesTwoIds($html);
     }
 
     public function test_two_fields_on_one_page_stay_independent()


### PR DESCRIPTION
## Was hier drin ist

Nur Tests. Kein Produktivcode angefasst, keine API-Änderung, kein Breaking Change.

Der Auftrag war, den Umbau aus `backlog-statamic-toc-v2-anker-vertrag` zu bauen: eine Quelle für Überschriften und Anker-IDs. **Der Umbau steht bereits vollständig auf `main`** — `Registry`, `Slugger`, `IdInjector`, `Extractors/{Bard,Html,Markdown}`, und der Modifier rechnet keine IDs mehr aus. Ich habe das gegen den Code geprüft, nicht aus dem Ticket übernommen. Es gab also nichts zu bauen.

Offen war die zweite Hälfte des Auftrags: die Randfälle, die der Vertragstest noch nicht festhielt.

## Neu im Vertrag

| Fall | Warum er fehlte |
|---|---|
| Leere Überschrift (`<h2></h2>`) | Gar nicht abgedeckt. Der Redakteur lässt einen Heading-Block leer stehen. |
| Überschrift ohne Text (Whitespace, `<br>`, leeres Inline-Markup) | Dito, als DataProvider mit drei Zeilen. |
| Titel ohne slugfähige Zeichen (`???`) | Der `section`-Fallback in `Slugger::unique` war nirgends gepinnt. |
| Manuell gesetzte `id` **unterhalb** der kollidierenden Überschrift | Die bestehende Abdeckung hatte die manuelle `id` immer oben. Dass `Slugger::assign` vorhandene IDs in einem eigenen Vorlauf beansprucht, hing an nichts. |
| `id` in anderer Notation (einfache Anführungszeichen, Großschreibung) | Der `hasId`-Guard im Injektor ist tolerant, der Test war es nicht. |
| Markdown-Feld: Liste aus der Quelle, IDs aus dem gerenderten HTML | Die normale Form einer Markdown-Seite. Zwei verschiedene Strings, ein Heading-Verlauf — genau das, was der `Registry`-Fingerprint überbrücken muss. |

## Zwei Löcher in den Hilfsfunktionen des Tests

Beide fanden sich beim Schreiben, beide hätten Zusicherungen aus dem falschen Grund grün gehalten:

1. `anchors()` matchte `href="#([^"]+)"`. Ein leeres `href="#"` fiel damit aus dem Ergebnis heraus — ein Listeneintrag, der nirgendwohin zeigt, sah aus wie kein Listeneintrag.
2. `ids()` las nur `id="…"` in Kleinschreibung mit doppelten Anführungszeichen. Für eine Überschrift, die sichtbar eine `id` trägt, meldete es „keine id".

## Was die Mutationsprobe gefunden hat

M4 (`hasId` erkennt nur doppelt quotierte Kleinschreibung) **überlebte im ersten Durchlauf**. Grund: erkennt der Injektor die einfach quotierte `id` nicht, hängt er eine zweite daneben. Der Browser behält die erste, die Liste zeigt auf denselben Wert — der Vertrag sah eingehalten aus, obwohl das HTML kaputt war.

Deshalb prüft `assertAnchorsResolve()` jetzt zusätzlich, dass keine Überschrift zwei `id`-Attribute trägt. Danach fällt M4.

## Testlauf

Vor dem Branch: `OK (129 Tests, 292 Assertions)`
Auf dem Branch: `OK (137 Tests, 363 Assertions)`

`pint --test` grün.

`phpstan analyse` konnte ich lokal nicht auswerten: interner Fehler beim Auflösen der `phpstorm-stubs` (`dom_c.stub`), Artefakt eines quer kopierten `vendor/`. Derselbe Fehler tritt auf einem **unveränderten** `main`-Checkout auf, hat also nichts mit diesem Branch zu tun. Die CI hat es entschieden: **Static analysis grün**, ebenso alle sechs Matrix-Zeilen und Code style.

## Mutationsprobe (real gelaufen, jeweils einzeln eingespielt und zurückgesetzt)

| Mutation | Ergebnis |
|---|---|
| M0 Injektor schreibt eine andere `id` als die Liste verlinkt (nur Dokumentseite) | **rot**, 16 von 18 |
| M1 `Slugger` behandelt eine textlose Überschrift nicht mehr als leer | **rot**, 4 |
| M2 kein `section`-Fallback für einen nicht slugfähigen Titel | **rot**, 1 |
| M3 vorhandene `id`s werden erst beim Vorbeilaufen beansprucht | **rot**, 1 |
| M4 `hasId` erkennt nur `id="…"` in Kleinschreibung | **rot**, 1 (nach der Verschärfung oben) |

Nach jeder Rücknahme wieder `OK (18 Tests, 99 Assertions)` im Vertragstest, Working Tree am Ende sauber.

Zwei Tests überleben M0, beide zu Recht: `test_no_heading_carries_two_ids` prüft nur Duplikate, und `test_excluding_a_heading_…` arbeitet direkt am `Parser` ohne zu rendern.

Ehrliche Grenze, unverändert gegenüber der Prüfung vom 01.08.: der Test prüft das Ergebnis, nicht die Architektur. Ein Modifier, der die `Registry` umgeht und einen frischen, zustandslosen `Slugger` benutzt, überlebt. Sobald die zweite Rechenstelle abweicht — und genau das war der v1-Fehler — fällt der Test.

## Nicht gemacht, bewusst

Kein Merge, kein Tag, kein Release, kein Packagist-Push. Draft, weil Adrian im Urlaub ist.

## Offene Fragen für Adrian

1. **Leere Überschrift: ist „aus beiden Seiten raus" die gewollte Regel?** Das ist der heutige Stand, und ich habe ihn festgeschrieben, nicht entschieden. Denkbar wäre auch, sie in der Liste zu zeigen und auf `#section` zeigen zu lassen. Kein Ticket sagt dazu etwas.
2. **Der `section`-Fallback ist ein magischer String** in `Slugger::unique`, nicht konfigurierbar. Für ein englischsprachig ausgeliefertes Addon vermutlich in Ordnung, aber niemand hat das entschieden.
3. Die Restpunkte aus dem Ticket bleiben offen und sind keine Bauarbeit: GitHub-Release für v2 (jüngstes Release ist `v1.9`, obwohl `v2.0.0` und `v2.1.0` getaggt sind), Packagist-Verifikation (packagist.org ist aus dieser Umgebung nicht erreichbar), und der veraltete Zahlenstand im Ticket-Text.
